### PR TITLE
Install strimzi 0.20.0 without requiring helm

### DIFF
--- a/hack/drogue.sh
+++ b/hack/drogue.sh
@@ -6,7 +6,6 @@ set -ex
 : "${MQTT:=true}"
 
 : "${INSTALL_DEPS:=true}"
-: "${INSTALL_STRIMZI:=${INSTALL_DEPS}}"
 : "${INSTALL_KNATIVE:=${INSTALL_DEPS}}"
 : "${INSTALL_KEYCLOAK_OPERATOR:=${INSTALL_DEPS}}"
 
@@ -23,7 +22,6 @@ fi
 
 # install pre-reqs
 
-[[ "$INSTALL_STRIMZI" == true ]] && source "$SCRIPTDIR/strimzi.sh"
 [[ "$INSTALL_KNATIVE" == true ]] && source "$SCRIPTDIR/knative.sh"
 [[ "$INSTALL_KEYCLOAK_OPERATOR" == true ]] && source "$SCRIPTDIR/sso.sh"
 

--- a/hack/strimzi.sh
+++ b/hack/strimzi.sh
@@ -4,21 +4,30 @@ set -ex
 
 : "${KAFKA_NS:=kafka}"
 : "${STRIMZI_VERSION:=0.20.0}"
-: "${CLUSTER:=minikube}"
-
-SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-DEPLOYDIR="$SCRIPTDIR/../deploy"
 
 #
 # Strimzi
 #
+if ! kubectl get ns $KAFKA_NS >/dev/null 2>&1; then
+  kubectl create ns $KAFKA_NS
+fi
+if ! kubectl -n $KAFKA_NS get deploy/strimzi-cluster-operator >/dev/null 2>&1; then
+  curl -L "https://github.com/strimzi/strimzi-kafka-operator/releases/download/${STRIMZI_VERSION}/strimzi-cluster-operator-${STRIMZI_VERSION}.yaml" \
+    | sed 's/myproject/${KAFKA_NS}/' \
+    | kubectl apply -n $KAFKA_NS -f -
 
-# create namespace
-if ! kubectl get ns $KAFKA_NS >/dev/null 2>&1; then kubectl create ns $KAFKA_NS; fi
-
-helm upgrade --install --wait --timeout 30m \
-  strimzi \
-  https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.20.0/strimzi-kafka-operator-helm-3-chart-0.20.0.tgz \
-  --set watchAnyNamespace=true \
-  -n "$KAFKA_NS" \
-  >/dev/null
+  # the following is required to watch all namespaces
+  kubectl -n $KAFKA_NS set env deploy/strimzi-cluster-operator STRIMZI_NAMESPACE=\*
+  if ! kubectl get clusterrolebinding strimzi-cluster-operator-namespaced >/dev/null 2>&1; then
+    kubectl create clusterrolebinding strimzi-cluster-operator-namespaced \
+      --clusterrole=strimzi-cluster-operator-namespaced \
+      --serviceaccount $KAFKA_NS:strimzi-cluster-operator
+    kubectl create clusterrolebinding strimzi-cluster-operator-entity-operator-delegation \
+      --clusterrole=strimzi-entity-operator \
+      --serviceaccount $KAFKA_NS:strimzi-cluster-operator
+    kubectl create clusterrolebinding strimzi-cluster-operator-topic-operator-delegation \
+      --clusterrole=strimzi-topic-operator \
+      --serviceaccount $KAFKA_NS:strimzi-cluster-operator
+  fi
+fi
+kubectl wait deployment --all --timeout=-1s --for=condition=Available -n $KAFKA_NS


### PR DESCRIPTION
I think it's only knative that's requiring strimzi -- correct me if
I'm wrong -- so collapsed the INSTALL_STRIMZI flag within
INSTALL_KNATIVE. It's still possible to invoke strimzi.sh to install
it separately, of course.