### PR TITLE
[#35] Fix "make test"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ all: build images test push
 CURRENT_DIR ?= $(strip $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST)))))
 TOP_DIR ?= $(CURRENT_DIR)
 IMAGE_TAG ?= latest
-BUILDER_IMAGE ?= ghcr.io/drogue-iot/builder:0.1.1
+BUILDER_IMAGE ?= ghcr.io/drogue-iot/builder:0.1.3
 
 MODULE:=$(basename $(shell realpath --relative-to $(TOP_DIR) $(CURRENT_DIR)))
 
@@ -87,7 +87,7 @@ host-build:
 # Run tests on the host, forking off into the build container.
 #
 host-test:
-	if [ -n "$($(CONTAINER) network ls --format '{{.Name}} | grep drogue')" ]; then $(CONTAINER) network create drogue; fi
+	if [ -z "$$($(CONTAINER) network ls --format '{{.Name}} | grep drogue')" ]; then $(CONTAINER) network create drogue; fi
 	$(CONTAINER) run --rm -t -v "$(TOP_DIR):/usr/src:z" $(TEST_CONTAINER_ARGS) "$(BUILDER_IMAGE)" make -j1 -C /usr/src/$(MODULE) container-test
 
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 
 CONTAINER ?= docker
 ifeq ($(CONTAINER),docker)
-TEST_CONTAINER_ARGS ?= -v /var/run/docker.sock:/var/run/docker.sock:z
+TEST_CONTAINER_ARGS ?= -v /var/run/docker.sock:/var/run/docker.sock:z --network drogue
 endif
 ifeq ($(CONTAINER),podman)
 TEST_CONTAINER_ARGS ?= --security-opt label=disable -v $(XDG_RUNTIME_DIR)/podman/podman.sock:/var/run/docker.sock:z
@@ -87,6 +87,7 @@ host-build:
 # Run tests on the host, forking off into the build container.
 #
 host-test:
+	if [ -n "$($(CONTAINER) network ls --format '{{.Name}} | grep drogue')" ]; then $(CONTAINER) network create drogue; fi
 	$(CONTAINER) run --rm -t -v "$(TOP_DIR):/usr/src:z" $(TEST_CONTAINER_ARGS) "$(BUILDER_IMAGE)" make -j1 -C /usr/src/$(MODULE) container-test
 
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ all: build images test push
 CURRENT_DIR ?= $(strip $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST)))))
 TOP_DIR ?= $(CURRENT_DIR)
 IMAGE_TAG ?= latest
-BUILDER_IMAGE ?= ghcr.io/drogue-iot/builder:0.1.3
+BUILDER_IMAGE ?= ghcr.io/drogue-iot/builder:0.1.4
 
 MODULE:=$(basename $(shell realpath --relative-to $(TOP_DIR) $(CURRENT_DIR)))
 

--- a/device-management-service/src/lib.rs
+++ b/device-management-service/src/lib.rs
@@ -27,7 +27,7 @@ macro_rules! crud {
         $scope
             .service({
                 let resource = concat!($base, stringify!($name), "s");
-                log::info!("{}", resource);
+                log::debug!("{}", resource);
                 web::resource(resource).route(web::post().to({
                     use $module as m;
                     m::create
@@ -35,7 +35,7 @@ macro_rules! crud {
             })
             .service({
                 let resource = concat!($base, stringify!($name), "s/{", stringify!($name), "_id}");
-                log::info!("{}", resource);
+                log::debug!("{}", resource);
 
                 web::resource(resource)
                     .name(stringify!($name))

--- a/test-common/src/lib.rs
+++ b/test-common/src/lib.rs
@@ -1,5 +1,6 @@
 use deadpool::managed::{PoolConfig, Timeouts};
 use std::io::{BufRead, BufReader};
+use std::process::Command;
 use std::{fs, path::PathBuf, time::Duration};
 use testcontainers::{clients::Cli, images::generic::GenericImage, Container, Docker, RunArgs};
 
@@ -110,7 +111,11 @@ impl<'c, C: Docker, SC> Drop for PostgresRunner<'c, C, SC> {
 }
 
 pub fn client() -> Cli {
-    Cli::podman()
+    let out = Command::new("podman").args(&["version"]).output();
+    match out {
+        Ok(_) => Cli::podman(),
+        _ => Cli::docker(),
+    }
 }
 
 pub fn db<C, SC, F>(cli: &C, f: F) -> anyhow::Result<PostgresRunner<C, SC>>

--- a/test-common/src/lib.rs
+++ b/test-common/src/lib.rs
@@ -1,4 +1,5 @@
 use deadpool::managed::{PoolConfig, Timeouts};
+use std::path::Path;
 use std::process::Command;
 use std::{fs, path::PathBuf, time::Duration};
 use testcontainers::{
@@ -19,17 +20,11 @@ pub struct PostgresRunner<'c, C: Docker, SC> {
 const MSG: &str = "[1] LOG:  database system is ready to accept connections";
 
 impl<'c, C: 'c + Docker, SC> PostgresRunner<'c, C, SC> {
-    pub fn new(cli: &'c C, config: SC) -> anyhow::Result<Self> {
+    pub fn new(cli: &'c C, config: SC, pc: deadpool_postgres::Config) -> anyhow::Result<Self> {
         log::info!("Starting postgres (containerized: {})", is_containerized());
 
         let image = GenericImage::new("docker.io/library/postgres:12")
-            .with_env_var("POSTGRES_PASSWORD", "mysecretpassword")
-            .with_volume(
-                Self::gather_sql()?
-                    .to_str()
-                    .ok_or_else(|| anyhow::anyhow!("Failed to generate SQL path"))?,
-                "/docker-entrypoint-initdb.d",
-            );
+            .with_env_var("POSTGRES_PASSWORD", "mysecretpassword");
 
         let image = match is_podman() {
             false => image.with_wait_for(WaitFor::message_on_stderr(MSG)),
@@ -47,29 +42,89 @@ impl<'c, C: 'c + Docker, SC> PostgresRunner<'c, C, SC> {
 
         let db = cli.run_with_args(image, args);
 
+        Self::init_db(pc)?;
+
         Ok(Self { config, db })
     }
 
+    /// Init database by executing all found SQL statement
+    fn init_db(config: deadpool_postgres::Config) -> anyhow::Result<()> {
+        // FIXME: this logic currently doesn't sort files, which might result in a problem
+        Self::find_all_sql(
+            |_| Ok(()),
+            |s, _| {
+                let mut cmd = Command::new("psql");
+                cmd.arg("-h")
+                    .arg(&config.host.as_ref().unwrap_or(&"localhost".into()))
+                    .arg("-p")
+                    .arg(config.port.as_ref().unwrap_or(&5432).to_string())
+                    .arg("-U")
+                    .arg(&config.user.as_ref().unwrap_or(&"postgres".into()))
+                    .env(
+                        "PGPASSWORD",
+                        &config.password.as_ref().unwrap_or(&"postgres".into()),
+                    )
+                    .arg("-d")
+                    .arg(&config.dbname.as_ref().unwrap_or(&"postgres".into()))
+                    .arg("-f")
+                    .arg(s.as_os_str());
+                log::info!("Running: {:?}", cmd);
+                let out = cmd.output()?;
+                log::info!("Out: {:?}", String::from_utf8(out.stdout));
+                log::info!("Err: {:?}", String::from_utf8(out.stderr));
+                if out.status.success() {
+                    Ok(())
+                } else {
+                    anyhow::bail!("Command failed: {}", out.status)
+                }
+            },
+        )?;
+        Ok(())
+    }
+
+    /// Used to gather all required SQL scripts in a directory
+    #[allow(dead_code)]
     fn gather_sql() -> anyhow::Result<PathBuf> {
+        Self::find_all_sql(
+            |t| {
+                if t.exists() {
+                    std::fs::remove_dir_all(&t)?;
+                }
+                std::fs::create_dir_all(&t)?;
+                Ok(())
+            },
+            |s, t| fs::copy(s, t).map_err(|err| err.into()).map(|_| ()),
+        )
+    }
+
+    fn find_all_sql<I, F>(i: I, f: F) -> anyhow::Result<PathBuf>
+    where
+        I: FnOnce(&Path) -> anyhow::Result<()>,
+        F: Fn(&Path, &Path) -> anyhow::Result<()>,
+    {
         let manifest_dir = std::env::var_os("CARGO_MANIFEST_DIR")
             .ok_or_else(|| anyhow::anyhow!("Missing environment variable 'CARGO_MANIFEST_DIR'"))?;
         let manifest_dir = PathBuf::from(manifest_dir);
 
         let target = manifest_dir.join("target/sql");
+        i(&target)?;
 
-        if target.exists() {
-            std::fs::remove_dir_all(&target)?;
-        }
-        std::fs::create_dir_all(&target)?;
-
-        Self::copy_sql(&manifest_dir.join("../database-common/migrations"), &target)?;
-        Self::copy_sql(&manifest_dir.join("tests/sql"), &target)?;
+        Self::find_sql(
+            &manifest_dir.join("../database-common/migrations"),
+            &target,
+            &f,
+        )?;
+        Self::find_sql(&manifest_dir.join("tests/sql"), &target, &f)?;
 
         // done
+
         Ok(target)
     }
 
-    fn copy_sql(source: &PathBuf, target: &PathBuf) -> anyhow::Result<()> {
+    fn find_sql<F>(source: &PathBuf, target: &PathBuf, f: &F) -> anyhow::Result<()>
+    where
+        F: Fn(&Path, &Path) -> anyhow::Result<()>,
+    {
         if !source.exists() {
             return Ok(());
         }
@@ -91,7 +146,7 @@ impl<'c, C: 'c + Docker, SC> PostgresRunner<'c, C, SC> {
             let target = target.join(format!("{}-up.sql", name));
             log::debug!("Add SQL file: {:?} -> {:?}", up, target);
 
-            fs::copy(up.path(), target)?;
+            f(up.path(), &target)?;
         }
 
         Ok(())
@@ -127,7 +182,7 @@ where
         false => "localhost",
     };
 
-    let config = f(deadpool_postgres::Config {
+    let pc = deadpool_postgres::Config {
         host: Some(host.into()),
         user: Some("postgres".into()),
         password: Some("mysecretpassword".into()),
@@ -142,7 +197,8 @@ where
         }),
 
         ..Default::default()
-    });
+    };
+    let config = f(pc.clone());
 
-    Ok(PostgresRunner::new(cli, config)?)
+    Ok(PostgresRunner::new(cli, config, pc)?)
 }


### PR DESCRIPTION
This PR fixes the situation, as least when you run Docker. Docker can be run in a way that is communicates with the host docker daemon, which allows the container to create "sibling containers".

For this we also need to use `psql` to create the database schema, as we cannot mount anything from the builder container into the postgres container.