### PR TITLE
Shorten the TTN examples and make them more copy paste friendly

### DIFF
--- a/docs/modules/ttn/pages/app.adoc
+++ b/docs/modules/ttn/pages/app.adoc
@@ -15,29 +15,20 @@ You will need create an account at The Things Network. As part of that you will 
 
 === Procedure
 
-Create a new application in Drogue Cloud:
+Create a new application in Drogue Cloud with the TTN-specific information:
 
 [source,shell]
 ----
-drg create application my-ttn-app
-----
-
-Next, add the TTN specific information:
-
-[source,json]
-----
-{
-    "spec": {
-        "ttn": {
-            "api": {
-                "apiKey": "...", <1>
-                "id": "my-app-alias", <2>
-                "owner": "my-user-name", <3>
-                "region": "eu1" <4>
-            }
+drg create application my-ttn-app --spec '{
+    "ttn": {
+        "api": {
+            "apiKey": "...", <1>
+            "id": "my-app-alias", <2>
+            "owner": "my-user-name", <3>
+            "region": "eu1" <4>
         }
     }
-}
+}'
 ----
 <1> The API key, must have access to create new applications for the provided owner.
 <2> The (optional) ID of the application in the TTN system. Defaults to the name of the application in Drogue Cloud. This valid must not be changed.
@@ -46,21 +37,7 @@ Next, add the TTN specific information:
 
 This will enable the integration and trigger the reconciliation process.
 
-You can do this with `drg` by executing:
-
-[source,shell]
-----
-drg create app my-ttn-app --spec '{
-    "ttn": {
-        "apiKey": "...",
-        "id": "my-app-alias",
-        "owner": "my-user-name",
-        "region": "eu1"
-    }
-}'
-----
-
-Or, you can use `drg edit app my-ttn-app` to interactively change the configuration.
+You can also use `drg edit app my-ttn-app` to change the configuration of an existing application.
 
 Taking a look at the TTN console, you should see the new application (`my-app-alias` in this case), and a
 webhook named `drogue-iot`.

--- a/docs/modules/ttn/pages/device.adoc
+++ b/docs/modules/ttn/pages/device.adoc
@@ -15,51 +15,26 @@ You will need the following information for your device:
 
 === Procedure
 
-Create a new device in Drogue Cloud:
+Create a new device in Drogue Cloud with TTN specific information:
 
 [source,shell]
 ----
-drg create --app my-ttn-app device my-ttn-device-1
-----
-
-Next, add the TTN specific information:
-
-[source,json]
-----
-{
-    "spec": {
-        "ttn": {
-            "app_eui": "0123456789ABCDEF",
-            "app_key": "0123456789ABCDEF...",
-            "dev_eui": "0123456789ABCDEF",
-            "frequency_plan_id": "...", <1>
-            "lorawan_phy_version": "...", <2>
-            "lorawan_version": "..." <3>
-        }
+drg create --app my-ttn-app device my-ttn-device-1 --spec '{
+    "ttn": {
+        "app_eui": "0123456789ABCDEF",
+        "app_key": "0123456789ABCDEF...",
+        "dev_eui": "0123456789ABCDEF",
+        "frequency_plan_id": "...", <1>
+        "lorawan_phy_version": "...", <2>
+        "lorawan_version": "..." <3>
     }
-}
+}'
 ----
 <1> An ID of the TTN supported frequency plans, e.g. `EU_863_870_TTN`. Also see: https://www.thethingsindustries.com/docs/reference/frequency-plans/
 <2> An ID of the TTN supported LoRa versions, e.g. `PHY_V1_0`
 <3> An ID of the TTN supported LoRa version, e.g. `MAC_V1_0`
 
-You can do this with `drg` by executing:
-
-[source,shell]
-----
-drg create device --app my-ttn-app my-ttn-device-1 --spec '{
-    "ttn": {
-        "app_eui": "0123456789ABCDEF",
-        "app_key": "0123456789ABCDEF...",
-        "dev_eui": "0123456789ABCDEF",
-        "frequency_plan_id": "...",
-        "lorawan_phy_version": "...",
-        "lorawan_version": "..."
-    }
-}'
-----
-
-Or, you can use `drg edit device --app my-ttn-app my-ttn-device-1` to interactively change the configuration.
+You can also use `drg edit device --app my-ttn-app my-ttn-device-1` to change the configuration of an existing device.
 
 == Deleting a device
 


### PR DESCRIPTION
For people who don't read the docs before pasting commands (like me), I think this will be slightly more readable.