### PR TITLE
[#49]: Gracefully handle missing command and payload

### DIFF
--- a/http-endpoint/src/command.rs
+++ b/http-endpoint/src/command.rs
@@ -22,12 +22,11 @@ pub async fn wait_for_command(
         Some(ttd) if ttd > 0 => {
             let mut receiver = commands.subscribe(id.clone());
             match timeout(Duration::from_secs(ttd), receiver.recv()).await {
-                Ok(command) => {
+                Ok(Some(cmd)) => {
                     commands.unsubscribe(id.clone());
-                    let cmd = command.unwrap();
                     Ok(HttpResponse::Ok()
                         .insert_header((HEADER_COMMAND, cmd.command))
-                        .body(cmd.payload.unwrap()))
+                        .body(cmd.payload.unwrap_or_default()))
                 }
                 _ => {
                     commands.unsubscribe(id.clone());


### PR DESCRIPTION
I think handling only the `Ok(Some(…))` case should do the trick. Than again, I am just guessing :)

I also think it is ok to send back an "empty" command.

Closes #49 