### PR TITLE
Create a composite Ingress resource

### DIFF
--- a/console-backend/api/index.yaml
+++ b/console-backend/api/index.yaml
@@ -19,14 +19,14 @@ tags:
   - name: API keys
     description: Manage access key to the API.
   - name: Registry
-    description: Manage Apps and devices in the registry.
+    description: Manage application and devices in the registry.
   - name: Application administration
     description: Manage applications members and authorizations.
   - name: User administration
     description: Manage users
   - name: Command & Control
     description: Send commands to devices and check the results.
-  - name: System Information
+  - name: System information
     description: Get information of the system.
 
 paths:
@@ -39,7 +39,7 @@ paths:
     get:
       description: "Get version"
       tags:
-        - System Information
+        - System information
       responses:
         "200":
           description: "Version response"

--- a/console-backend/src/info.rs
+++ b/console-backend/src/info.rs
@@ -1,26 +1,14 @@
 use actix_web::{get, web, HttpResponse, Responder};
-
-use drogue_cloud_service_api::version::DrogueVersion;
-use drogue_cloud_service_common::endpoints::EndpointSourceType;
-
-use serde_json::json;
+use drogue_cloud_service_api::{endpoints::Endpoints, version::DrogueVersion};
 
 #[get("/info")]
-pub async fn get_info(endpoint_source: web::Data<EndpointSourceType>) -> impl Responder {
-    match endpoint_source.eval_endpoints().await {
-        Ok(endpoints) => HttpResponse::Ok().json(endpoints),
-        Err(err) => HttpResponse::InternalServerError().json(json!( {"error": err.to_string()})),
-    }
+pub async fn get_info(endpoints: web::Data<Endpoints>) -> impl Responder {
+    HttpResponse::Ok().json(endpoints)
 }
 
 #[get("/drogue-endpoints")]
-pub async fn get_public_endpoints(
-    endpoint_source: web::Data<EndpointSourceType>,
-) -> impl Responder {
-    match endpoint_source.eval_endpoints().await {
-        Ok(endpoints) => HttpResponse::Ok().json(endpoints.publicize()),
-        Err(err) => HttpResponse::InternalServerError().json(json!( {"error": err.to_string()})),
-    }
+pub async fn get_public_endpoints(endpoints: web::Data<Endpoints>) -> impl Responder {
+    HttpResponse::Ok().json(endpoints.publicize())
 }
 
 #[get("/drogue-version")]

--- a/deploy/base/api/ingress.yaml
+++ b/deploy/base/api/ingress.yaml
@@ -1,0 +1,44 @@
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: api
+spec:
+  rules:
+    - # we omit the host here, it needs to be set later on, based on the application domain
+      http:
+        paths:
+          - path: /.well-known/
+            pathType: Prefix
+            backend:
+              service:
+                name: console-backend
+                port:
+                  name: endpoint
+          - path: /api/keys/
+            pathType: Prefix
+            backend:
+              service:
+                name: console-backend
+                port:
+                  name: endpoint
+          - path: /api/admin/
+            pathType: Prefix
+            backend:
+              service:
+                name: console-backend
+                port:
+                  name: endpoint
+          - path: /api/registry/
+            pathType: Prefix
+            backend:
+              service:
+                name: registry
+                port:
+                  name: api
+          - path: /api/command/
+            pathType: Prefix
+            backend:
+              service:
+                name: command-endpoint
+                port:
+                  name: endpoint

--- a/deploy/base/api/kustomization.yaml
+++ b/deploy/base/api/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ingress.yaml

--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -13,3 +13,4 @@ bases:
   - service/console
   - service/registry
   - integration/mqtt
+  - api

--- a/deploy/minikube/api/ingress.yaml
+++ b/deploy/minikube/api/ingress.yaml
@@ -1,0 +1,43 @@
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: api
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /.well-known/
+            pathType: Prefix
+            backend:
+              service:
+                name: console-backend
+                port:
+                  name: endpoint
+          - path: /api/keys/
+            pathType: Prefix
+            backend:
+              service:
+                name: console-backend
+                port:
+                  name: endpoint
+          - path: /api/admin/
+            pathType: Prefix
+            backend:
+              service:
+                name: console-backend
+                port:
+                  name: endpoint
+          - path: /api/registry/
+            pathType: Prefix
+            backend:
+              service:
+                name: registry
+                port:
+                  name: api
+          - path: /api/command/
+            pathType: Prefix
+            backend:
+              service:
+                name: command-endpoint
+                port:
+                  name: endpoint

--- a/deploy/minikube/api/kustomization.yaml
+++ b/deploy/minikube/api/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../base/api
+
+resources:
+  - ingress.yaml

--- a/deploy/minikube/kustomization.yaml
+++ b/deploy/minikube/kustomization.yaml
@@ -14,3 +14,4 @@ bases:
   - service/console
   - service/registry
   - integration/mqtt
+  - ../base/api

--- a/deploy/minikube/service/registry/kustomization.yaml
+++ b/deploy/minikube/service/registry/kustomization.yaml
@@ -6,4 +6,3 @@ bases:
 
 patchesStrategicMerge:
   - deployment-user-auth.yaml
-  - service.yaml

--- a/deploy/openshift/kustomization.yaml
+++ b/deploy/openshift/kustomization.yaml
@@ -18,3 +18,4 @@ bases:
   - service/console
   - service/registry
   - integration/mqtt
+  - ../base/api

--- a/scripts/.editorconfig
+++ b/scripts/.editorconfig
@@ -1,0 +1,7 @@
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.sh]
+indent_style = space
+indent_size = 4

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -13,6 +13,30 @@
 
 die() { echo "$*" 1>&2 ; exit 1; }
 
+# Get the application domain
+function domain() {
+    local domain
+    case $CLUSTER in
+        kubernetes)
+            domain=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type == "ExternalIP")].address}').nip.io
+            ;;
+        kind)
+            domain=$(kubectl get node kind-control-plane -o jsonpath='{.status.addresses[?(@.type == "InternalIP")].address}').nip.io
+            ;;
+        minikube)
+            domain=$(minikube ip).nip.io
+            ;;
+        openshift)
+            domain=$(kubectl -n openshift-ingress-operator get ingresscontrollers.operator.openshift.io default -o jsonpath='{.status.domain}')
+            ;;
+        *)
+            echo "Unknown Kubernetes platform: $CLUSTER ... unable to extract endpoints"
+            exit 1
+            ;;
+    esac
+    echo "$domain"
+}
+
 function service_url() {
   local name="$1"
   shift
@@ -20,12 +44,12 @@ function service_url() {
 
 case $CLUSTER in
     kubernetes)
-        DOMAIN=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type == "ExternalIP")].address}').nip.io
+        DOMAIN=$(domain)
         PORT=$(kubectl get service -n "$DROGUE_NS" "$name" -o jsonpath='{.spec.ports[0].nodePort}')
         URL=${scheme:-http}://$name.$DOMAIN:$PORT
         ;;
     kind)
-        DOMAIN=$(kubectl get node kind-control-plane -o jsonpath='{.status.addresses[?(@.type == "InternalIP")].address}').nip.io
+        DOMAIN=$(domain)
         PORT=$(kubectl get service -n "$DROGUE_NS" "$name" -o jsonpath='{.spec.ports[0].nodePort}')
         URL=${scheme:-http}://$name.$DOMAIN:$PORT
         ;;
@@ -44,15 +68,32 @@ esac;
 echo "$URL"
 }
 
+function route_url() {
+    local name="$1"
+    shift
+
+    case $CLUSTER in
+        openshift)
+            URL="$(kubectl get route -n "$DROGUE_NS" "$name" -o 'jsonpath={ .spec.host }')"
+            if [ -n "$URL" ]; then
+                URL="https://$URL"
+            fi
+            ;;
+        *)
+            ingress_url "$name"
+            ;;
+    esac
+}
+
 function ingress_url() {
   local name="$1"
   shift
 
 case $CLUSTER in
    openshift)
-        URL="$(kubectl get route -n "$DROGUE_NS" "$name" -o 'jsonpath={ .spec.host }')"
-        if [ -n "$URL" ]; then
-          URL="https://$URL"
+        HOST="$(kubectl get ingress -n "$DROGUE_NS" "$name" -o 'jsonpath={ .status.loadBalancer.ingress[0].hostname }')"
+        if [ -n "$HOST" ]; then
+          URL="https://$HOST"
         fi
         ;;
    kubernetes)
@@ -60,7 +101,7 @@ case $CLUSTER in
         if [ "$name" == "keycloak" ]; then
             name="$name-endpoint"
         fi
-        DOMAIN=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type == "ExternalIP")].address}').nip.io
+        DOMAIN=$(domain)
         PORT=$(kubectl get service -n "$DROGUE_NS" "$name" -o jsonpath='{.spec.ports[0].nodePort}')
         if [ -n "$DOMAIN" ]; then
           URL="http://$name.$DOMAIN:$PORT"
@@ -72,16 +113,16 @@ case $CLUSTER in
         if [ "$name" == "keycloak" ]; then
             name="$name-endpoint"
         fi
-        DOMAIN=$(kubectl get node kind-control-plane -o jsonpath='{.status.addresses[?(@.type == "InternalIP")].address}').nip.io
+        DOMAIN=$(domain)
         PORT=$(kubectl get service -n "$DROGUE_NS" "$name" -o jsonpath='{.spec.ports[0].nodePort}')
         if [ -n "$DOMAIN" ]; then
           URL="http://$name.$DOMAIN:$PORT"
         fi
         ;;
    *)
-        URL=$(kubectl get ingress -n "$DROGUE_NS" "$name"  -o 'jsonpath={ .status.loadBalancer.ingress[0].ip }')
-        if [ -n "$URL" ]; then
-          URL="http://$URL"
+        IP=$(kubectl get ingress -n "$DROGUE_NS" "$name"  -o 'jsonpath={ .status.loadBalancer.ingress[0].ip }')
+        if [ -n "$IP" ]; then
+          URL="http://$name-$IP.nip.io"
         fi
         ;;
 esac;

--- a/scripts/drogue.sh
+++ b/scripts/drogue.sh
@@ -80,25 +80,29 @@ kubectl -n "$DROGUE_NS" apply -k "$DEPLOYDIR/$CLUSTER/"
 
 # Patch some of the deployments to to allow persistent volume access
 if [ "$CLUSTER" == "kubernetes" ]; then
-    # Some time to let resources show up
-    sleep 60
+    # Wait for the resources to show up
+    wait_for_resource deployment/keycloak-postgresql
+    wait_for_resource deployment/postgres
+    wait_for_resource deployment/grafana
 
     kubectl -n "$DROGUE_NS" patch deployment keycloak-postgresql -p '{"spec":{"template":{"spec":{"securityContext":{"fsGroup": 2000, "runAsNonRoot": true, "runAsUser": 1000}}}}}'
     kubectl -n "$DROGUE_NS" patch deployment postgres -p '{"spec":{"template":{"spec":{"securityContext":{"fsGroup": 2000, "runAsNonRoot": true, "runAsUser": 1000}}}}}'
     kubectl -n "$DROGUE_NS" patch deployment grafana -p '{"spec":{"template":{"spec":{"securityContext":{"fsGroup": 2000, "runAsNonRoot": true, "runAsUser": 1000}}}}}'
 fi
 
-# Remove the unnecessary and wrong host entry for keycloak ingress
+# Remove the wrong host entry for keycloak ingress
 
 case $CLUSTER in
-   openshift)
+    openshift)
+        # we must set the hostname on openshift before calling the "endpoints.sh" script
+        kubectl -n "$DROGUE_NS" patch ingress/api --type json --patch '[{"op": "add", "path": "/spec/rules/0/host", "value": "'"$(domain)"'"}]' || true
         wait_for_resource route/keycloak
         ;;
-   *)
+    *)
         wait_for_resource ingress/keycloak
         kubectl -n "$DROGUE_NS" patch ingress/keycloak --type json --patch '[{"op": "remove", "path": "/spec/rules/0/host"}]' || true
         ;;
-esac;
+esac
 
 # source the endpoint information
 
@@ -130,10 +134,11 @@ fi
 
 # Update the console endpoints
 
+kubectl -n "$DROGUE_NS" set env deployment/console-backend "ENDPOINTS__API_URL=$API_URL"
 kubectl -n "$DROGUE_NS" set env deployment/console-backend "ENDPOINTS__HTTP_ENDPOINT_URL=$HTTP_ENDPOINT_URL"
 kubectl -n "$DROGUE_NS" set env deployment/console-backend "ENDPOINTS__MQTT_ENDPOINT_HOST=$MQTT_ENDPOINT_HOST" "ENDPOINTS__MQTT_ENDPOINT_PORT=$MQTT_ENDPOINT_PORT"
 kubectl -n "$DROGUE_NS" set env deployment/console-backend "ENDPOINTS__MQTT_INTEGRATION_HOST=$MQTT_INTEGRATION_HOST" "ENDPOINTS__MQTT_INTEGRATION_PORT=$MQTT_INTEGRATION_PORT"
-kubectl -n "$DROGUE_NS" set env deployment/console-backend "ENDPOINTS__DEVICE_REGISTRY_URL=$MGMT_URL" "ENDPOINTS__COMMAND_ENDPOINT_URL=$COMMAND_ENDPOINT_URL"
+kubectl -n "$DROGUE_NS" set env deployment/console-backend "ENDPOINTS__DEVICE_REGISTRY_URL=$API_URL" "ENDPOINTS__COMMAND_ENDPOINT_URL=$COMMAND_ENDPOINT_URL"
 kubectl -n "$DROGUE_NS" set env deployment/console-backend "SSO_URL=$SSO_URL" "ENDPOINTS__REDIRECT_URL=$CONSOLE_URL"
 kubectl -n "$DROGUE_NS" set env deployment/console-backend "DEMOS=Grafana Dashboard=$DASHBOARD_URL"
 
@@ -153,13 +158,28 @@ kubectl -n "$DROGUE_NS" set env deployment/ttn-operator "SSO_URL=$SSO_URL" "ENDP
 
 kubectl -n "$DROGUE_NS" set env deployment/grafana "SSO_URL=$SSO_URL" "GF_SERVER_ROOT_URL=$DASHBOARD_URL"
 
+# we still need to "backend" URL here, since the backend can still do a few things that we don't want in the API
 kubectl -n "$DROGUE_NS" set env deployment/console-frontend "BACKEND_URL=$BACKEND_URL"
 
 if [ "$CLUSTER" != "openshift" ]; then
-  kubectl -n "$DROGUE_NS" annotate ingress/keycloak --overwrite 'nginx.ingress.kubernetes.io/proxy-buffer-size=16k'
+    kubectl -n "$DROGUE_NS" annotate ingress/keycloak --overwrite 'nginx.ingress.kubernetes.io/proxy-buffer-size=16k'
 fi
 kubectl -n "$DROGUE_NS" patch keycloakclient/client --type json --patch "[{\"op\": \"replace\",\"path\": \"/spec/client/redirectUris\",\"value\": [\"${CONSOLE_URL}\", \"${CONSOLE_URL}/*\", \"http://localhost:*\"]}]"
 kubectl -n "$DROGUE_NS" patch keycloakclient/client-grafana --type json --patch "[{\"op\": \"replace\",\"path\": \"/spec/client/redirectUris/0\",\"value\": \"$DASHBOARD_URL/login/generic_oauth\"}]"
+
+# set the host names in the ingresses
+
+case $CLUSTER in
+    openshift)
+        # nothing to do here
+        ;;
+    *)
+        # The host will by applied late, based on the IP of its status section
+        kubectl -n "$DROGUE_NS" patch ingress/keycloak --type json --patch '[{"op": "add", "path": "/spec/rules/0/host", "value": "'"${SSO_HOST}"'"}]' || true
+        kubectl -n "$DROGUE_NS" patch ingress/api --type json --patch '[{"op": "add", "path": "/spec/rules/0/host", "value": "'"${API_HOST}"'"}]' || true
+        ;;
+esac;
+
 
 # wait for other Knative services
 

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -37,7 +37,7 @@ echo
 bold "Login in with 'drg':"
 bold "---------------------"
 echo
-echo "  drg login $BACKEND_URL"
+echo "  drg login $API_URL"
 echo
 bold "Create an initial application and device:"
 bold "------------------------------"

--- a/service-api/src/endpoints.rs
+++ b/service-api/src/endpoints.rs
@@ -50,6 +50,7 @@ impl Endpoints {
             mqtt: None,
             mqtt_integration: None,
             sso: self.sso.clone(),
+            api: self.api.clone(),
             issuer_url: self.issuer_url.clone(),
             redirect_url: None,
             registry: self.registry.clone(),


### PR DESCRIPTION
This change creates a composite ingress resource, for all APIs.

This also uses Ingress on OpenShift, which (when configured with a hostname) will create OpenShift Routes. In the scripts this gets a bit more complicated, but we now have a single Ingress resource for all platforms. At least for the APIs.

Some APIs from the console backend are still required. I hope we can get rid of them too. And so we could drop the "console-backend" service and route too.