### PR TITLE
add an alias section in devices spec

### DIFF
--- a/console-backend/api/index.yaml
+++ b/console-backend/api/index.yaml
@@ -870,6 +870,19 @@ components:
               $ref: '#/components/schemas/DeviceCredentials'
         gatewaySelector:
           $ref: '#/components/schemas/GatewaySelector'
+        aliases:
+          $ref: '#/components/schemas/Aliases'
+
+
+    Aliases:
+      type: array
+      items:
+        type: String
+        maxLength: 255
+        description: |
+          A list of alternates names that the device can authenticates with.
+          Must conform to UTF-8.
+
 
     GatewaySelector:
       type: object


### PR DESCRIPTION
This assumes all the aliases going through the API are of type `manual`, so the type will be added by the back-end. I've put the same limitation as for the deviceID. 

Question : does an alias can be use interchangeably with the original ID ? 
I tried to create a device on the sndbox with a `user` credential, which should create an alias with the username : 
```
drg create device foo
drg set password  foo bar --username f00
```
I was not able to retrieve the device with the alias afterward. (`drg get device f00` -> not found)

Also : Do I add `spec.aliases` to the App object as well ?  