### PR TITLE
Use "official" cloudevents actix beta.8 branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,7 +856,7 @@ dependencies = [
 [[package]]
 name = "cloudevents-sdk"
 version = "0.4.0"
-source = "git+https://github.com/jcrossley3/sdk-rust?branch=actix-4-beta.8#57a7a837e1ec326148924ac5847156112c01d357"
+source = "git+https://github.com/cloudevents/sdk-rust?branch=actix-web-4.0.0-beta.8#538b3bd5b91d6a5dc64036d25137eebaffe31105"
 dependencies = [
  "actix-web",
  "async-trait",
@@ -867,7 +867,7 @@ dependencies = [
  "delegate-attr",
  "futures",
  "hostname",
- "lazy_static",
+ "http",
  "rdkafka",
  "reqwest",
  "serde 1.0.126",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,4 +48,4 @@ testcontainers = { git = "https://github.com/testcontainers/testcontainers-rs", 
 #actix-web-httpauth = { git = "https://github.com/ctron/actix-extras", rev = "5f08b566a04842667672d5802be2604b6054e285" }
 
 # required du to missing "beta" versions for more recent "beta" actix versions
-cloudevents-sdk = { git = "https://github.com/jcrossley3/sdk-rust", branch = "actix-4-beta.8" } # FIXME: pre-release branch
+cloudevents-sdk = { git = "https://github.com/cloudevents/sdk-rust", branch = "actix-web-4.0.0-beta.8" } # FIXME: pre-release branch

--- a/mqtt-endpoint/src/cloudevents_sdk_ntex.rs
+++ b/mqtt-endpoint/src/cloudevents_sdk_ntex.rs
@@ -6,13 +6,10 @@ use cloudevents::message::{
 };
 use cloudevents::{message, Event};
 use futures::StreamExt;
-use http::{header, header::HeaderName, HeaderValue};
+use http::{header::HeaderName, HeaderValue};
 use lazy_static::lazy_static;
 use ntex::{http::HttpMessage, web, web::HttpRequest};
 use std::convert::TryFrom;
-
-use std::collections::HashMap;
-use std::str::FromStr;
 
 macro_rules! unwrap_optional_header {
     ($headers:expr, $name:expr) => {
@@ -32,36 +29,7 @@ macro_rules! header_value_to_str {
     };
 }
 
-macro_rules! str_name_to_header {
-    ($attribute:expr) => {
-        HeaderName::from_str($attribute).map_err(|e| cloudevents::message::Error::Other {
-            source: Box::new(e),
-        })
-    };
-}
-
-macro_rules! attribute_name_to_header {
-    ($attribute:expr) => {
-        str_name_to_header!(&["ce-", $attribute].concat())
-    };
-}
-
-fn attributes_to_headers(
-    it: impl Iterator<Item = &'static str>,
-) -> HashMap<&'static str, HeaderName> {
-    it.map(|s| {
-        if s == "datacontenttype" {
-            (s, header::CONTENT_TYPE)
-        } else {
-            (s, attribute_name_to_header!(s).unwrap())
-        }
-    })
-    .collect()
-}
-
 lazy_static! {
-    pub(crate) static ref ATTRIBUTES_TO_HEADERS: HashMap<&'static str, HeaderName> =
-        attributes_to_headers(SpecVersion::all_attribute_names());
     pub(crate) static ref SPEC_VERSION_HEADER: HeaderName =
         HeaderName::from_static("ce-specversion");
     pub(crate) static ref CLOUDEVENTS_JSON_HEADER: HeaderValue =


### PR DESCRIPTION
This revealed some unused ntex code since `SpecVersion::all_attribute_names()` no longer exists.