### PR TITLE
Add a websocket integration service

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,7 +197,7 @@ You will need to have `npm` installed, as it will drive parts of the build.
 You will also need `wasm-bindgen`, which can be installed locally using:
 
 ~~~
-cargo install wasm-bindgen-cli --version "=0.2.71
+cargo install wasm-bindgen-cli --version "=0.2.71"
 ~~~
 
 NOTE: The version (here `0.2.71`) must match the exact version of the version in `console-frontend/Cargo.toml`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2412,6 +2412,7 @@ dependencies = [
  "reqwest",
  "serde 1.0.126",
  "serde_json",
+ "url",
  "uuid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2023,7 +2023,7 @@ dependencies = [
  "async-trait",
  "base64 0.13.0",
  "bytes 1.0.1",
- "cloudevents-sdk 0.4.0",
+ "cloudevents-sdk",
  "drogue-client 0.7.0",
  "drogue-cloud-endpoint-common",
  "drogue-cloud-event-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,10 +8,10 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3720d0064a0ce5c0de7bd93bdb0a6caebab2a9b5668746145d7b3b0c5da02914"
 dependencies = [
- "actix-rt",
+ "actix-rt 2.2.0",
  "actix_derive",
  "bitflags",
- "bytes",
+ "bytes 1.0.1",
  "crossbeam-channel",
  "futures-core",
  "futures-sink",
@@ -20,10 +20,10 @@ dependencies = [
  "log",
  "once_cell",
  "parking_lot",
- "pin-project-lite",
+ "pin-project-lite 0.2.7",
  "smallvec",
- "tokio",
- "tokio-util",
+ "tokio 1.9.0",
+ "tokio-util 0.6.7",
 ]
 
 [[package]]
@@ -39,18 +39,53 @@ dependencies = [
 
 [[package]]
 name = "actix-codec"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78d1833b3838dbe990df0f1f87baf640cf6146e898166afe401839d1b001e570"
+dependencies = [
+ "bitflags",
+ "bytes 0.5.6",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project 0.4.28",
+ "tokio 0.2.25",
+ "tokio-util 0.3.1",
+]
+
+[[package]]
+name = "actix-codec"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d5dbeb2d9e51344cb83ca7cc170f1217f9fe25bfc50160e6e200b5c31c1019a"
 dependencies = [
  "bitflags",
- "bytes",
+ "bytes 1.0.1",
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite",
- "tokio",
- "tokio-util",
+ "pin-project-lite 0.2.7",
+ "tokio 1.9.0",
+ "tokio-util 0.6.7",
+]
+
+[[package]]
+name = "actix-connect"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177837a10863f15ba8d3ae3ec12fac1099099529ed20083a27fdfe247381d0dc"
+dependencies = [
+ "actix-codec 0.3.0",
+ "actix-rt 1.1.1",
+ "actix-service 1.0.6",
+ "actix-utils 2.0.0",
+ "derive_more",
+ "either",
+ "futures-util",
+ "http",
+ "log",
+ "trust-dns-proto",
+ "trust-dns-resolver",
 ]
 
 [[package]]
@@ -59,7 +94,7 @@ version = "0.6.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01552b8facccd5d7a4cc5d8e2b07d306160c97a4968181c2db965533389c8725"
 dependencies = [
- "actix-service",
+ "actix-service 2.0.0",
  "actix-web",
  "derive_more",
  "futures-util",
@@ -70,46 +105,103 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "452299e87817ae5673910e53c243484ca38be3828db819b6011736fc6982e874"
+dependencies = [
+ "actix-codec 0.3.0",
+ "actix-connect",
+ "actix-rt 1.1.1",
+ "actix-service 1.0.6",
+ "actix-threadpool",
+ "actix-utils 2.0.0",
+ "base64 0.13.0",
+ "bitflags",
+ "brotli2",
+ "bytes 0.5.6",
+ "cookie 0.14.4",
+ "copyless",
+ "derive_more",
+ "either",
+ "encoding_rs",
+ "flate2",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "fxhash",
+ "h2 0.2.7",
+ "http",
+ "httparse",
+ "indexmap",
+ "itoa",
+ "language-tags 0.2.2",
+ "lazy_static",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project 1.0.8",
+ "rand 0.7.3",
+ "regex",
+ "serde 1.0.126",
+ "serde_json",
+ "serde_urlencoded",
+ "sha-1",
+ "slab",
+ "time 0.2.27",
+]
+
+[[package]]
+name = "actix-http"
 version = "3.0.0-beta.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cd16d6b846983ffabfd081e1a67abd7698094fcbe7b3d9bcf1acbc6f546a516"
 dependencies = [
- "actix-codec",
- "actix-rt",
- "actix-service",
+ "actix-codec 0.4.0",
+ "actix-rt 2.2.0",
+ "actix-service 2.0.0",
  "actix-tls",
- "actix-utils",
+ "actix-utils 3.0.0",
  "ahash",
  "base64 0.13.0",
  "bitflags",
  "brotli2",
- "bytes",
+ "bytes 1.0.1",
  "bytestring",
  "derive_more",
  "encoding_rs",
  "flate2",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.3",
  "http",
  "httparse",
  "itoa",
- "language-tags",
+ "language-tags 0.3.2",
  "local-channel",
  "log",
  "mime",
  "once_cell",
  "percent-encoding",
  "pin-project 1.0.8",
- "pin-project-lite",
+ "pin-project-lite 0.2.7",
  "rand 0.8.4",
  "regex",
  "serde 1.0.126",
  "sha-1",
  "smallvec",
  "time 0.2.27",
- "tokio",
+ "tokio 1.9.0",
  "zstd",
+]
+
+[[package]]
+name = "actix-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ca8ce00b267af8ccebbd647de0d61e0674b6e61185cc7a592ff88772bed655"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -137,13 +229,28 @@ dependencies = [
 
 [[package]]
 name = "actix-rt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "143fcc2912e0d1de2bcf4e2f720d2a60c28652ab4179685a1ee159e0fb3db227"
+dependencies = [
+ "actix-macros 0.1.3",
+ "actix-threadpool",
+ "copyless",
+ "futures-channel",
+ "futures-util",
+ "smallvec",
+ "tokio 0.2.25",
+]
+
+[[package]]
+name = "actix-rt"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc7d7cd957c9ed92288a7c3c96af81fa5291f65247a76a34dac7b6af74e52ba0"
 dependencies = [
- "actix-macros",
+ "actix-macros 0.2.1",
  "futures-core",
- "tokio",
+ "tokio 1.9.0",
 ]
 
 [[package]]
@@ -152,15 +259,25 @@ version = "2.0.0-beta.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26369215fcc3b0176018b3b68756a8bcc275bb000e6212e454944913a1f9bf87"
 dependencies = [
- "actix-rt",
- "actix-service",
- "actix-utils",
+ "actix-rt 2.2.0",
+ "actix-service 2.0.0",
+ "actix-utils 3.0.0",
  "futures-core",
  "log",
- "mio",
+ "mio 0.7.13",
  "num_cpus",
  "slab",
- "tokio",
+ "tokio 1.9.0",
+]
+
+[[package]]
+name = "actix-service"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0052435d581b5be835d11f4eb3bce417c8af18d87ddf8ace99f8e67e595882bb"
+dependencies = [
+ "futures-util",
+ "pin-project 0.4.28",
 ]
 
 [[package]]
@@ -171,7 +288,22 @@ checksum = "77f5f9d66a8730d0fae62c26f3424f5751e5518086628a40b7ab6fca4a705034"
 dependencies = [
  "futures-core",
  "paste",
- "pin-project-lite",
+ "pin-project-lite 0.2.7",
+]
+
+[[package]]
+name = "actix-threadpool"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d209f04d002854b9afd3743032a27b066158817965bf5d036824d19ac2cc0e30"
+dependencies = [
+ "derive_more",
+ "futures-channel",
+ "lazy_static",
+ "log",
+ "num_cpus",
+ "parking_lot",
+ "threadpool",
 ]
 
 [[package]]
@@ -180,10 +312,10 @@ version = "3.0.0-beta.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65b7bb60840962ef0332f7ea01a57d73a24d2cb663708511ff800250bbfef569"
 dependencies = [
- "actix-codec",
- "actix-rt",
- "actix-service",
- "actix-utils",
+ "actix-codec 0.4.0",
+ "actix-rt 2.2.0",
+ "actix-service 2.0.0",
+ "actix-utils 3.0.0",
  "derive_more",
  "futures-core",
  "http",
@@ -191,8 +323,28 @@ dependencies = [
  "openssl",
  "tokio-openssl",
  "tokio-rustls",
- "tokio-util",
+ "tokio-util 0.6.7",
  "webpki-roots",
+]
+
+[[package]]
+name = "actix-utils"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9022dec56632d1d7979e59af14f0597a28a830a9c1c7fec8b2327eb9f16b5a"
+dependencies = [
+ "actix-codec 0.3.0",
+ "actix-rt 1.1.1",
+ "actix-service 1.0.6",
+ "bitflags",
+ "bytes 0.5.6",
+ "either",
+ "futures-channel",
+ "futures-sink",
+ "futures-util",
+ "log",
+ "pin-project 0.4.28",
+ "slab",
 ]
 
 [[package]]
@@ -202,7 +354,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e491cbaac2e7fc788dfff99ff48ef317e23b3cf63dbaf7aaab6418f40f92aa94"
 dependencies = [
  "local-waker",
- "pin-project-lite",
+ "pin-project-lite 0.2.7",
 ]
 
 [[package]]
@@ -211,27 +363,27 @@ version = "4.0.0-beta.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c503f726f895e55dac39adeafd14b5ee00cc956796314e9227fc7ae2e176f443"
 dependencies = [
- "actix-codec",
- "actix-http",
- "actix-macros",
+ "actix-codec 0.4.0",
+ "actix-http 3.0.0-beta.8",
+ "actix-macros 0.2.1",
  "actix-router",
- "actix-rt",
+ "actix-rt 2.2.0",
  "actix-server",
- "actix-service",
+ "actix-service 2.0.0",
  "actix-tls",
- "actix-utils",
+ "actix-utils 3.0.0",
  "actix-web-codegen",
  "ahash",
- "bytes",
+ "bytes 1.0.1",
  "cfg-if 1.0.0",
- "cookie",
+ "cookie 0.15.1",
  "derive_more",
  "either",
  "encoding_rs",
  "futures-core",
  "futures-util",
  "itoa",
- "language-tags",
+ "language-tags 0.3.2",
  "log",
  "mime",
  "once_cell",
@@ -242,9 +394,26 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2",
+ "socket2 0.4.0",
  "time 0.2.27",
  "url",
+]
+
+[[package]]
+name = "actix-web-actors"
+version = "4.0.0-beta.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7db5c2c78a2606e6634abee4973a4924221cfab66e48f23844256e4fb8ce0f42"
+dependencies = [
+ "actix",
+ "actix-codec 0.4.0",
+ "actix-http 3.0.0-beta.8",
+ "actix-web",
+ "bytes 1.0.1",
+ "bytestring",
+ "futures-core",
+ "pin-project 1.0.8",
+ "tokio 1.9.0",
 ]
 
 [[package]]
@@ -264,7 +433,7 @@ version = "0.6.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "264d0eb4698d59493cafc96554c3919837115f8c4e9040a3790c2b55400ff758"
 dependencies = [
- "actix-service",
+ "actix-service 2.0.0",
  "actix-web",
  "base64 0.13.0",
  "futures-util",
@@ -389,9 +558,9 @@ dependencies = [
  "parking",
  "polling",
  "slab",
- "socket2",
+ "socket2 0.4.0",
  "waker-fn",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -433,7 +602,7 @@ dependencies = [
  "memchr",
  "num_cpus",
  "once_cell",
- "pin-project-lite",
+ "pin-project-lite 0.2.7",
  "pin-utils",
  "slab",
  "wasm-bindgen-futures",
@@ -470,7 +639,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -481,25 +650,49 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "awc"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b381e490e7b0cfc37ebc54079b0413d8093ef43d14a4e4747083f7fa47a9e691"
+dependencies = [
+ "actix-codec 0.3.0",
+ "actix-http 2.2.0",
+ "actix-rt 1.1.1",
+ "actix-service 1.0.6",
+ "base64 0.13.0",
+ "bytes 0.5.6",
+ "cfg-if 1.0.0",
+ "derive_more",
+ "futures-core",
+ "log",
+ "mime",
+ "percent-encoding",
+ "rand 0.7.3",
+ "serde 1.0.126",
+ "serde_json",
+ "serde_urlencoded",
+]
+
+[[package]]
+name = "awc"
 version = "3.0.0-beta.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "364ef81705bf38403a3c3da4fab9eeec1e1503cd72dd6cd7c4259d2a6b08aa98"
 dependencies = [
- "actix-codec",
- "actix-http",
- "actix-rt",
- "actix-service",
+ "actix-codec 0.4.0",
+ "actix-http 3.0.0-beta.8",
+ "actix-rt 2.2.0",
+ "actix-service 2.0.0",
  "base64 0.13.0",
- "bytes",
+ "bytes 1.0.1",
  "cfg-if 1.0.0",
- "cookie",
+ "cookie 0.15.1",
  "derive_more",
  "futures-core",
  "itoa",
  "log",
  "mime",
  "percent-encoding",
- "pin-project-lite",
+ "pin-project-lite 0.2.7",
  "rand 0.8.4",
  "rustls",
  "serde 1.0.126",
@@ -708,6 +901,12 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+
+[[package]]
+name = "bytes"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
@@ -718,7 +917,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90706ba19e97b90786e19dc0d5e2abd80008d99d4c0c5d1ad0b5e72cec7c494d"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "serde 1.0.126",
 ]
 
@@ -777,7 +976,7 @@ dependencies = [
  "serde 1.0.126",
  "time 0.1.44",
  "wasm-bindgen",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -819,7 +1018,7 @@ dependencies = [
  "async-trait",
  "base64 0.12.3",
  "bitflags",
- "bytes",
+ "bytes 1.0.1",
  "chrono",
  "delegate-attr",
  "futures",
@@ -850,7 +1049,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f81d3a631b71e85e6af642e22169738d1b258a7ead4d486b01781f321d56d69"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "coap-lite",
  "futures",
  "log",
@@ -858,9 +1057,9 @@ dependencies = [
  "num-traits 0.2.14",
  "regex",
  "serde 1.0.126",
- "tokio",
+ "tokio 1.9.0",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.6.7",
  "url",
 ]
 
@@ -935,6 +1134,17 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cookie"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03a5d7b21829bc7b4bf4754a978a241ae54ea55a40f92bb20216e54096f4b951"
+dependencies = [
+ "percent-encoding",
+ "time 0.2.27",
+ "version_check",
+]
+
+[[package]]
+name = "cookie"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f1c7727e460397e56abc4bddc1d49e07a1ad78fc98eb2e1c8f032a58a2f80d"
@@ -943,6 +1153,12 @@ dependencies = [
  "time 0.2.27",
  "version_check",
 ]
+
+[[package]]
+name = "copyless"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2df960f5d869b2dd8532793fde43eb5427cceb126c929747a26823ab0eeb536"
 
 [[package]]
 name = "core-foundation"
@@ -1181,7 +1397,7 @@ dependencies = [
  "crossbeam-queue",
  "num_cpus",
  "serde 1.0.126",
- "tokio",
+ "tokio 1.9.0",
 ]
 
 [[package]]
@@ -1194,7 +1410,7 @@ dependencies = [
  "config 0.11.0",
  "num_cpus",
  "serde 1.0.126",
- "tokio",
+ "tokio 1.9.0",
 ]
 
 [[package]]
@@ -1209,7 +1425,7 @@ dependencies = [
  "futures",
  "log",
  "serde 1.0.126",
- "tokio",
+ "tokio 1.9.0",
  "tokio-postgres",
 ]
 
@@ -1300,7 +1516,7 @@ checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
  "redox_users",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1366,7 +1582,7 @@ dependencies = [
 name = "drogue-cloud-admin-service"
 version = "0.6.0"
 dependencies = [
- "actix-http",
+ "actix-http 3.0.0-beta.8",
  "actix-web",
  "anyhow",
  "async-trait",
@@ -1387,16 +1603,16 @@ dependencies = [
  "serde 1.0.126",
  "serde_json",
  "thiserror",
- "tokio",
+ "tokio 1.9.0",
 ]
 
 [[package]]
 name = "drogue-cloud-api-key-service"
 version = "0.6.0"
 dependencies = [
- "actix-http",
- "actix-rt",
- "actix-service",
+ "actix-http 3.0.0-beta.8",
+ "actix-rt 2.2.0",
+ "actix-service 2.0.0",
  "actix-web",
  "anyhow",
  "async-trait",
@@ -1429,7 +1645,7 @@ dependencies = [
  "sha3",
  "testcontainers",
  "thiserror",
- "tokio",
+ "tokio 1.9.0",
  "url",
 ]
 
@@ -1437,8 +1653,8 @@ dependencies = [
 name = "drogue-cloud-authentication-service"
 version = "0.6.0"
 dependencies = [
- "actix-rt",
- "actix-service",
+ "actix-rt 2.2.0",
+ "actix-service 2.0.0",
  "actix-web",
  "actix-web-httpauth",
  "anyhow",
@@ -1472,7 +1688,7 @@ dependencies = [
  "sha2",
  "testcontainers",
  "thiserror",
- "tokio",
+ "tokio 1.9.0",
  "tokio-postgres",
 ]
 
@@ -1480,11 +1696,11 @@ dependencies = [
 name = "drogue-cloud-coap-endpoint"
 version = "0.1.0"
 dependencies = [
- "actix-rt",
+ "actix-rt 2.2.0",
  "actix-web",
  "anyhow",
  "async-trait",
- "bytes",
+ "bytes 1.0.1",
  "bytestring",
  "chrono",
  "cloudevents-sdk",
@@ -1503,7 +1719,7 @@ dependencies = [
  "serde 1.0.126",
  "serde_json",
  "serde_urlencoded",
- "tokio",
+ "tokio 1.9.0",
  "url",
 ]
 
@@ -1549,7 +1765,7 @@ dependencies = [
  "actix-web-httpauth",
  "anyhow",
  "async-trait",
- "awc",
+ "awc 3.0.0-beta.7",
  "biscuit",
  "chrono",
  "chrono-tz",
@@ -1648,7 +1864,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "thiserror",
- "tokio",
+ "tokio 1.9.0",
  "tokio-postgres",
  "uuid",
 ]
@@ -1658,14 +1874,14 @@ name = "drogue-cloud-device-management-service"
 version = "0.7.0"
 dependencies = [
  "actix-cors",
- "actix-http",
- "actix-rt",
+ "actix-http 3.0.0-beta.8",
+ "actix-rt 2.2.0",
  "actix-web",
  "actix-web-httpauth",
  "anyhow",
  "async-trait",
  "base64 0.13.0",
- "bytes",
+ "bytes 1.0.1",
  "chrono",
  "config 0.10.1",
  "deadpool 0.7.0",
@@ -1696,7 +1912,7 @@ dependencies = [
  "serial_test",
  "testcontainers",
  "thiserror",
- "tokio",
+ "tokio 1.9.0",
  "tokio-postgres",
  "url",
  "uuid",
@@ -1738,7 +1954,7 @@ dependencies = [
  "serde_json",
  "snafu",
  "thiserror",
- "tokio",
+ "tokio 1.9.0",
  "uuid",
  "x509-parser",
 ]
@@ -1765,7 +1981,7 @@ dependencies = [
 name = "drogue-cloud-http-endpoint"
 version = "0.7.0"
 dependencies = [
- "actix-rt",
+ "actix-rt 2.2.0",
  "actix-tls",
  "actix-web",
  "anyhow",
@@ -1795,7 +2011,7 @@ dependencies = [
  "serde 1.0.126",
  "serde_json",
  "snafu",
- "tokio",
+ "tokio 1.9.0",
  "uuid",
 ]
 
@@ -1806,8 +2022,8 @@ dependencies = [
  "actix-web",
  "async-trait",
  "base64 0.13.0",
- "bytes",
- "cloudevents-sdk",
+ "bytes 1.0.1",
+ "cloudevents-sdk 0.4.0",
  "drogue-client 0.7.0",
  "drogue-cloud-endpoint-common",
  "drogue-cloud-event-common",
@@ -1830,7 +2046,7 @@ version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bytes",
+ "bytes 1.0.1",
  "bytestring",
  "cloudevents-sdk",
  "dotenv",
@@ -1855,7 +2071,7 @@ dependencies = [
  "rustls",
  "serde 1.0.126",
  "serde_json",
- "tokio",
+ "tokio 1.9.0",
  "uuid",
  "webpki",
 ]
@@ -1866,7 +2082,7 @@ version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bytes",
+ "bytes 1.0.1",
  "bytestring",
  "cloudevents-sdk",
  "dotenv",
@@ -1895,7 +2111,7 @@ dependencies = [
  "rustls",
  "serde 1.0.126",
  "serde_json",
- "tokio",
+ "tokio 1.9.0",
  "url",
  "uuid",
  "webpki",
@@ -1923,7 +2139,7 @@ dependencies = [
  "serde 1.0.126",
  "serde_json",
  "thiserror",
- "tokio",
+ "tokio 1.9.0",
  "tokio-postgres",
 ]
 
@@ -1977,7 +2193,7 @@ dependencies = [
  "serde 1.0.126",
  "serde_json",
  "thiserror",
- "tokio",
+ "tokio 1.9.0",
  "uuid",
 ]
 
@@ -2010,8 +2226,8 @@ dependencies = [
 name = "drogue-cloud-service-common"
 version = "0.7.0"
 dependencies = [
- "actix-rt",
- "actix-service",
+ "actix-rt 2.2.0",
+ "actix-service 2.0.0",
  "actix-web",
  "actix-web-httpauth",
  "anyhow",
@@ -2040,7 +2256,7 @@ dependencies = [
  "serde 1.0.126",
  "serde_json",
  "thiserror",
- "tokio",
+ "tokio 1.9.0",
  "url",
  "webpki",
 ]
@@ -2089,7 +2305,7 @@ dependencies = [
  "serde 1.0.126",
  "serde_json",
  "thiserror",
- "tokio",
+ "tokio 1.9.0",
  "url",
 ]
 
@@ -2128,7 +2344,7 @@ dependencies = [
  "serde 1.0.126",
  "serde_json",
  "thiserror",
- "tokio",
+ "tokio 1.9.0",
  "url",
  "x509-parser",
 ]
@@ -2137,8 +2353,8 @@ dependencies = [
 name = "drogue-cloud-user-auth-service"
 version = "0.7.0"
 dependencies = [
- "actix-rt",
- "actix-service",
+ "actix-rt 2.2.0",
+ "actix-service 2.0.0",
  "actix-web",
  "actix-web-httpauth",
  "anyhow",
@@ -2169,8 +2385,34 @@ dependencies = [
  "sha2",
  "testcontainers",
  "thiserror",
- "tokio",
+ "tokio 1.9.0",
  "tokio-postgres",
+]
+
+[[package]]
+name = "drogue-cloud-websocket-integration"
+version = "0.6.0"
+dependencies = [
+ "actix",
+ "actix-http 3.0.0-beta.8",
+ "actix-web",
+ "actix-web-actors",
+ "actix-web-httpauth",
+ "anyhow",
+ "awc 2.0.3",
+ "bytes 0.5.6",
+ "dotenv",
+ "drogue-client 0.7.0",
+ "drogue-cloud-integration-common",
+ "drogue-cloud-service-api",
+ "drogue-cloud-service-common",
+ "env_logger 0.8.4",
+ "futures",
+ "log",
+ "reqwest",
+ "serde 1.0.126",
+ "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -2282,6 +2524,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "enum-as-inner"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c5f0096a91d210159eceb2ff5e1c4da18388a170e1e3ce948aac9c8fdbbf595"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2403,6 +2657,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+dependencies = [
+ "bitflags",
+ "fuchsia-zircon-sys",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+
+[[package]]
 name = "funty"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2467,7 +2737,7 @@ dependencies = [
  "futures-io",
  "memchr",
  "parking",
- "pin-project-lite",
+ "pin-project-lite 0.2.7",
  "waker-fn",
 ]
 
@@ -2510,11 +2780,20 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite",
+ "pin-project-lite 0.2.7",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -2621,11 +2900,11 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.3"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
+checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -2633,8 +2912,28 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio",
- "tokio-util",
+ "tokio 0.2.25",
+ "tokio-util 0.3.1",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
+dependencies = [
+ "bytes 1.0.1",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio 1.9.0",
+ "tokio-util 0.6.7",
  "tracing",
 ]
 
@@ -2658,7 +2957,7 @@ checksum = "f0b7591fb62902706ae8e7aaff416b1b0fa2c0fd0878b46dc13baa3712d8a855"
 dependencies = [
  "base64 0.13.0",
  "bitflags",
- "bytes",
+ "bytes 1.0.1",
  "headers-core",
  "http",
  "mime",
@@ -2717,7 +3016,7 @@ checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
 dependencies = [
  "libc",
  "match_cfg",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2726,7 +3025,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "fnv",
  "itoa",
 ]
@@ -2737,9 +3036,9 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "http",
- "pin-project-lite",
+ "pin-project-lite 0.2.7",
 ]
 
 [[package]]
@@ -2785,19 +3084,19 @@ version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b61cf2d1aebcf6e6352c97b81dc2244ca29194be1b276f5d8ad5c6330fffb11"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.3",
  "http",
  "http-body",
  "httparse",
  "httpdate",
  "itoa",
- "pin-project-lite",
- "socket2",
- "tokio",
+ "pin-project-lite 0.2.7",
+ "socket2 0.4.0",
+ "tokio 1.9.0",
  "tower-service",
  "tracing",
  "want",
@@ -2813,7 +3112,7 @@ dependencies = [
  "hyper",
  "log",
  "rustls",
- "tokio",
+ "tokio 1.9.0",
  "tokio-rustls",
  "webpki",
 ]
@@ -2825,8 +3124,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
  "hyper",
- "pin-project-lite",
- "tokio",
+ "pin-project-lite 0.2.7",
+ "tokio 1.9.0",
  "tokio-io-timeout",
 ]
 
@@ -2836,10 +3135,10 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "hyper",
  "native-tls",
- "tokio",
+ "tokio 1.9.0",
  "tokio-native-tls",
 ]
 
@@ -2884,6 +3183,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "iovec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "ipconfig"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7e2f18aece9709094573a9f24f483c4f65caa4298e2f7ae1b71cc65d853fad7"
+dependencies = [
+ "socket2 0.3.19",
+ "widestring",
+ "winapi 0.3.9",
+ "winreg 0.6.2",
 ]
 
 [[package]]
@@ -2989,7 +3309,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbff78f6da26dde0d74188966d23fc763431d730d0f766ecf7699209f8fc243c"
 dependencies = [
  "base64 0.13.0",
- "bytes",
+ "bytes 1.0.1",
  "chrono",
  "http",
  "percent-encoding",
@@ -3004,6 +3324,16 @@ name = "keccak"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]
 
 [[package]]
 name = "keycloak"
@@ -3023,7 +3353,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21d3c79fb97a822a63ce9422f7302484748032c808954898ba248705e99ea110"
 dependencies = [
  "base64 0.13.0",
- "bytes",
+ "bytes 1.0.1",
  "chrono",
  "dirs-next",
  "either",
@@ -3043,9 +3373,9 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "thiserror",
- "tokio",
+ "tokio 1.9.0",
  "tokio-native-tls",
- "tokio-util",
+ "tokio-util 0.6.7",
  "tower",
  "tower-http",
  "tracing",
@@ -3096,8 +3426,8 @@ dependencies = [
  "serde_json",
  "smallvec",
  "snafu",
- "tokio",
- "tokio-util",
+ "tokio 1.9.0",
+ "tokio-util 0.6.7",
  "tracing",
 ]
 
@@ -3109,6 +3439,12 @@ checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
 dependencies = [
  "log",
 ]
+
+[[package]]
+name = "language-tags"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 
 [[package]]
 name = "language-tags"
@@ -3207,6 +3543,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map 0.5.4",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3274,15 +3619,57 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.6.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
+dependencies = [
+ "cfg-if 0.1.10",
+ "fuchsia-zircon",
+ "fuchsia-zircon-sys",
+ "iovec",
+ "kernel32-sys",
+ "libc",
+ "log",
+ "miow 0.2.2",
+ "net2",
+ "slab",
+ "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
 dependencies = [
  "libc",
  "log",
- "miow",
+ "miow 0.3.7",
  "ntapi",
- "winapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "mio-uds"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
+dependencies = [
+ "iovec",
+ "libc",
+ "mio 0.6.23",
+]
+
+[[package]]
+name = "miow"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
+dependencies = [
+ "kernel32-sys",
+ "net2",
+ "winapi 0.2.8",
+ "ws2_32-sys",
 ]
 
 [[package]]
@@ -3291,7 +3678,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3332,6 +3719,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "net2"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "nom"
 version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3361,7 +3759,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3373,19 +3771,19 @@ dependencies = [
  "ahash",
  "base64 0.13.0",
  "bitflags",
- "bytes",
+ "bytes 1.0.1",
  "bytestring",
  "derive_more",
  "encoding_rs",
  "futures-core",
  "futures-sink",
- "h2",
+ "h2 0.3.3",
  "http",
  "httparse",
  "httpdate",
  "log",
  "mime",
- "mio",
+ "mio 0.7.13",
  "nanorand",
  "ntex-codec",
  "ntex-macros",
@@ -3396,7 +3794,7 @@ dependencies = [
  "num_cpus",
  "openssl",
  "percent-encoding",
- "pin-project-lite",
+ "pin-project-lite 0.2.7",
  "regex",
  "rustls",
  "serde 1.0.126",
@@ -3404,8 +3802,8 @@ dependencies = [
  "serde_urlencoded",
  "sha-1",
  "slab",
- "socket2",
- "tokio",
+ "socket2 0.4.0",
+ "tokio 1.9.0",
  "tokio-openssl",
  "tokio-rustls",
  "webpki",
@@ -3419,12 +3817,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b88f1ddc712a0fd33da2a399d2b2caf1aa6eb1e2438d140552050e24d3a64c76"
 dependencies = [
  "bitflags",
- "bytes",
+ "bytes 1.0.1",
  "futures-core",
  "futures-sink",
  "log",
  "ntex-service",
- "tokio",
+ "tokio 1.9.0",
 ]
 
 [[package]]
@@ -3448,7 +3846,7 @@ dependencies = [
  "derive_more",
  "log",
  "ntex",
- "pin-project-lite",
+ "pin-project-lite 0.2.7",
  "serde 1.0.126",
  "serde_json",
 ]
@@ -3473,7 +3871,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b3cc7cc7d1c30f93e0fc04676b415531fb89fa96d41d4c77ba0569211c10460"
 dependencies = [
  "ntex-service",
- "tokio",
+ "tokio 1.9.0",
 ]
 
 [[package]]
@@ -3483,7 +3881,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a845b8def9e7f99904675a4842f4c96e219254597f720d091b8663217aee5f4"
 dependencies = [
  "ntex-util",
- "pin-project-lite",
+ "pin-project-lite 0.2.7",
 ]
 
 [[package]]
@@ -3495,7 +3893,7 @@ dependencies = [
  "bitflags",
  "futures-core",
  "futures-sink",
- "pin-project-lite",
+ "pin-project-lite 0.2.7",
  "slab",
 ]
 
@@ -3760,7 +4158,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb233f06c2307e1f5ce2ecad9f8121cffbbee2c95428f44ea85222e460d0d213"
 dependencies = [
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3800,7 +4198,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3924,6 +4322,12 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
+
+[[package]]
+name = "pin-project-lite"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
@@ -3978,7 +4382,7 @@ dependencies = [
  "libc",
  "log",
  "wepoll-ffi",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3989,7 +4393,7 @@ checksum = "ff3e0f70d32e20923cabf2df02913be7c1842d4c772db8065c00fcfdd1d1bff3"
 dependencies = [
  "base64 0.13.0",
  "byteorder",
- "bytes",
+ "bytes 1.0.1",
  "fallible-iterator",
  "hmac",
  "md-5",
@@ -4005,7 +4409,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "430f4131e1b7657b0cd9a2b0c3408d77c9a43a042d300b8c77f981dffcc43a2f"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "chrono",
  "fallible-iterator",
  "postgres-protocol",
@@ -4122,7 +4526,7 @@ dependencies = [
  "libc",
  "rand_core 0.3.1",
  "rdrand",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4260,7 +4664,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "slab",
- "tokio",
+ "tokio 1.9.0",
 ]
 
 [[package]]
@@ -4335,7 +4739,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4345,7 +4749,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246e9f61b9bb77df069a947682be06e31ac43ea37862e244a69f177694ea6d22"
 dependencies = [
  "base64 0.13.0",
- "bytes",
+ "bytes 1.0.1",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -4361,12 +4765,12 @@ dependencies = [
  "mime",
  "native-tls",
  "percent-encoding",
- "pin-project-lite",
+ "pin-project-lite 0.2.7",
  "rustls",
  "serde 1.0.126",
  "serde_json",
  "serde_urlencoded",
- "tokio",
+ "tokio 1.9.0",
  "tokio-native-tls",
  "tokio-rustls",
  "url",
@@ -4374,7 +4778,17 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
- "winreg",
+ "winreg 0.7.0",
+]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
+dependencies = [
+ "hostname",
+ "quick-error",
 ]
 
 [[package]]
@@ -4389,7 +4803,7 @@ dependencies = [
  "spin",
  "untrusted",
  "web-sys",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4525,7 +4939,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
  "lazy_static",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4794,7 +5208,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6be9f7d5565b1483af3e72975e2dee33879b3b86bd48c0929fccf6585d79e65a"
 dependencies = [
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4861,12 +5275,23 @@ dependencies = [
 
 [[package]]
 name = "socket2"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "socket2"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
 dependencies = [
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -5025,7 +5450,7 @@ dependencies = [
  "rand 0.8.4",
  "redox_syscall",
  "remove_dir_all",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -5081,6 +5506,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
 name = "time"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5088,7 +5522,7 @@ checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -5103,7 +5537,7 @@ dependencies = [
  "stdweb",
  "time-macros",
  "version_check",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -5156,22 +5590,42 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
+dependencies = [
+ "bytes 0.5.6",
+ "futures-core",
+ "iovec",
+ "lazy_static",
+ "libc",
+ "memchr",
+ "mio 0.6.23",
+ "mio-uds",
+ "pin-project-lite 0.1.12",
+ "signal-hook-registry",
+ "slab",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "tokio"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b7b349f11a7047e6d1276853e612d152f5e8a352c61917887cc2169e2366b4c"
 dependencies = [
  "autocfg",
- "bytes",
+ "bytes 1.0.1",
  "libc",
  "memchr",
- "mio",
+ "mio 0.7.13",
  "num_cpus",
  "once_cell",
  "parking_lot",
- "pin-project-lite",
+ "pin-project-lite 0.2.7",
  "signal-hook-registry",
  "tokio-macros",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -5180,8 +5634,8 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90c49f106be240de154571dd31fbe48acb10ba6c6dd6f6517ad603abffa42de9"
 dependencies = [
- "pin-project-lite",
- "tokio",
+ "pin-project-lite 0.2.7",
+ "tokio 1.9.0",
 ]
 
 [[package]]
@@ -5202,7 +5656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
- "tokio",
+ "tokio 1.9.0",
 ]
 
 [[package]]
@@ -5214,7 +5668,7 @@ dependencies = [
  "futures",
  "openssl",
  "openssl-sys",
- "tokio",
+ "tokio 1.9.0",
 ]
 
 [[package]]
@@ -5225,19 +5679,19 @@ checksum = "2d2b1383c7e4fb9a09e292c7c6afb7da54418d53b045f1c1fac7a911411a2b8b"
 dependencies = [
  "async-trait",
  "byteorder",
- "bytes",
+ "bytes 1.0.1",
  "fallible-iterator",
  "futures",
  "log",
  "parking_lot",
  "percent-encoding",
  "phf",
- "pin-project-lite",
+ "pin-project-lite 0.2.7",
  "postgres-protocol",
  "postgres-types",
- "socket2",
- "tokio",
- "tokio-util",
+ "socket2 0.4.0",
+ "tokio 1.9.0",
+ "tokio-util 0.6.7",
 ]
 
 [[package]]
@@ -5247,7 +5701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
  "rustls",
- "tokio",
+ "tokio 1.9.0",
  "webpki",
 ]
 
@@ -5258,8 +5712,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
 dependencies = [
  "futures-core",
- "pin-project-lite",
- "tokio",
+ "pin-project-lite 0.2.7",
+ "tokio 1.9.0",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
+dependencies = [
+ "bytes 0.5.6",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite 0.1.12",
+ "tokio 0.2.25",
 ]
 
 [[package]]
@@ -5268,13 +5736,13 @@ version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.2.7",
  "slab",
- "tokio",
+ "tokio 1.9.0",
 ]
 
 [[package]]
@@ -5295,8 +5763,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project 1.0.8",
- "tokio",
- "tokio-util",
+ "tokio 1.9.0",
+ "tokio-util 0.6.7",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5309,7 +5777,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b56efe69aa0ad2b5da6b942e57ea9f6fe683b7a314d4ff48662e2c8838de1"
 dependencies = [
  "base64 0.13.0",
- "bytes",
+ "bytes 1.0.1",
  "futures-core",
  "futures-util",
  "http",
@@ -5340,7 +5808,7 @@ checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.2.7",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -5366,12 +5834,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project 1.0.8",
+ "tracing",
+]
+
+[[package]]
 name = "treediff"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "761e8d5ad7ce14bb82b7e61ccc0ca961005a275a060b9644a2431aa11553c2ff"
 dependencies = [
  "serde_json",
+]
+
+[[package]]
+name = "trust-dns-proto"
+version = "0.19.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cad71a0c0d68ab9941d2fb6e82f8fb2e86d9945b94e1661dd0aaea2b88215a9"
+dependencies = [
+ "async-trait",
+ "cfg-if 1.0.0",
+ "enum-as-inner",
+ "futures",
+ "idna",
+ "lazy_static",
+ "log",
+ "rand 0.7.3",
+ "smallvec",
+ "thiserror",
+ "tokio 0.2.25",
+ "url",
+]
+
+[[package]]
+name = "trust-dns-resolver"
+version = "0.19.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f593b371175db53a26d0b38ed2978fafb9e9e8d3868b1acd753ea18df0ceb"
+dependencies = [
+ "cfg-if 0.1.10",
+ "futures",
+ "ipconfig",
+ "lazy_static",
+ "log",
+ "lru-cache",
+ "resolv-conf",
+ "smallvec",
+ "thiserror",
+ "tokio 0.2.25",
+ "trust-dns-proto",
 ]
 
 [[package]]
@@ -5454,6 +5971,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom 0.2.3",
+ "serde 1.0.126",
 ]
 
 [[package]]
@@ -5530,7 +6048,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
 dependencies = [
  "same-file",
- "winapi",
+ "winapi 0.3.9",
  "winapi-util",
 ]
 
@@ -5674,6 +6192,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
+
+[[package]]
+name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5682,6 +6212,12 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -5695,7 +6231,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -5706,11 +6242,30 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winreg"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "winreg"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "ws2_32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "api-key-service",
     "admin-service",
     "event-common",
+    "websocket-integration",
 ]
 
 [patch.crates-io]

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ ALL_IMAGES=\
 	mqtt-integration \
 	ttn-operator \
 	topic-operator \
-
+    websocket-integration \
 
 #
 # Active images to build

--- a/console-frontend/src/examples/consume.rs
+++ b/console-frontend/src/examples/consume.rs
@@ -188,10 +188,18 @@ impl Component for ConsumeData {
                 r#"websocat {}/{} -H="Authorization: Bearer {}""#,
                 ws.url, self.props.data.app_id, token,
             );
+            let drg_cmd = format!("drg stream --app {}", self.props.data.app_id,);
             cards.push(html!{
                 <Card title=html!{"Consume device data using a Websocket"}>
                     <div>
                         {"The data, published by devices, can also be consumed using a websocket."}
+                    </div>
+                    <div>
+                        {"Drg allows to easily get the stream:"}
+                    </div>
+                    <Clipboard code=true readonly=true variant=ClipboardVariant::Expandable value=drg_cmd/>
+                    <div>
+                        {"With a websocket client like websocat:"}
                     </div>
                     <div>
                         <Switch

--- a/console-frontend/src/examples/consume.rs
+++ b/console-frontend/src/examples/consume.rs
@@ -179,6 +179,35 @@ impl Component for ConsumeData {
             });
         }
 
+        if let Some(ws) = &self.props.endpoints.websocket_integration {
+            let token = match self.props.data.drg_token {
+                true => "\"$(drg token)\"".into(),
+                false => format!("\"{}\"", self.props.token.access_token),
+            };
+            let consume_websocket_cmd = format!(
+                r#"websocat {}/{} -H="Authorization: Bearer {}""#,
+                ws.url, self.props.data.app_id, token,
+            );
+            cards.push(html!{
+                <Card title=html!{"Consume device data using a Websocket"}>
+                    <div>
+                        {"The data, published by devices, can also be consumed using a websocket."}
+                    </div>
+                    <div>
+                        <Switch
+                            checked=self.props.data.drg_token
+                            label="Use 'drg token' to get the access token" label_off="Show current token in example"
+                            on_change=self.link.callback(|data| Msg::SetDrgToken(data))
+                            />
+                    </div>
+                    <div>
+                        {"Run the following command in a new terminal window:"}
+                    </div>
+                    <Clipboard code=true readonly=true variant=ClipboardVariant::Expandable value=consume_websocket_cmd/>
+                </Card>
+            });
+        }
+
         let actions: Vec<Action> =
             vec![Action::new("Try it!", self.link.callback(|_| Msg::OpenSpy))];
 

--- a/console-frontend/src/pages/overview.rs
+++ b/console-frontend/src/pages/overview.rs
@@ -91,6 +91,10 @@ impl Overview {
             integration_cards.push(self.render_mqtt_endpoint(&mqtt, "MQTT integration"));
         }
 
+        if let Some(ws) = &endpoints.websocket_integration {
+            integration_cards.push(self.render_card("Websocket integration", &ws.url, false));
+        }
+
         for (label, url) in &endpoints.demos {
             demo_cards.push(self.render_card(label, url, true));
         }

--- a/deploy/profiles/kind.yaml
+++ b/deploy/profiles/kind.yaml
@@ -16,3 +16,6 @@ integrations:
   mqtt:
     ingress:
       port: 30002
+  websocket:
+    ingress:
+      port: 30004

--- a/deploy/profiles/kind.yaml
+++ b/deploy/profiles/kind.yaml
@@ -17,5 +17,6 @@ integrations:
     ingress:
       port: 30002
   websocket:
+    insecure: true
     ingress:
       port: 30004

--- a/deploy/profiles/minikube.yaml
+++ b/deploy/profiles/minikube.yaml
@@ -16,3 +16,6 @@ integrations:
   mqtt:
     ingress:
       port: 30002
+  websocket:
+    ingress:
+      port: 30004

--- a/deploy/profiles/minikube.yaml
+++ b/deploy/profiles/minikube.yaml
@@ -17,5 +17,6 @@ integrations:
     ingress:
       port: 30002
   websocket:
+    insecure: true
     ingress:
       port: 30004

--- a/scripts/cmd/__endpoints.sh
+++ b/scripts/cmd/__endpoints.sh
@@ -11,6 +11,9 @@ MQTT_ENDPOINT_PORT="$(get_env deploy/console-backend endpoint ENDPOINTS__MQTT_EN
 MQTT_INTEGRATION_HOST="$(get_env deploy/console-backend endpoint ENDPOINTS__MQTT_INTEGRATION_HOST)"
 MQTT_INTEGRATION_PORT="$(get_env deploy/console-backend endpoint ENDPOINTS__MQTT_INTEGRATION_PORT)"
 
+WEBSOCKET_INTEGRATION_URL="$(get_env deploy/console-backend endpoint ENDPOINTS__WEBSOCKET_INTEGRATION_URL)"
+WEBSOCKET_INTEGRATION_HOST="$(echo "$WEBSOCKET_INTEGRATION_URL" | sed -E -e 's/:[0-9]+$//' -e 's|^https?://||' )"
+
 HTTP_ENDPOINT_URL="$(get_env deploy/console-backend endpoint ENDPOINTS__HTTP_ENDPOINT_URL)"
 HTTP_ENDPOINT_HOST="$(echo "$HTTP_ENDPOINT_URL" | sed -E -e 's/:[0-9]+$//' -e 's|^https?://||' )"
 
@@ -32,6 +35,7 @@ if [[ -z "$SILENT" ]]; then
         echo "MQTT Endpoint:    $MQTT_ENDPOINT_HOST:$MQTT_ENDPOINT_PORT"
         echo
         echo "MQTT Integration: $MQTT_INTEGRATION_HOST:$MQTT_INTEGRATION_PORT"
+        echo "Websocket Integration: $WEBSOCKET_INTEGRATION_URL ($WEBSOCKET_INTEGRATION_HOST)"
         echo
         bold "========================================================"
         bold "  Examples"

--- a/service-api/src/endpoints.rs
+++ b/service-api/src/endpoints.rs
@@ -37,6 +37,8 @@ pub struct Endpoints {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mqtt_integration: Option<MqttEndpoint>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub websocket_integration: Option<HttpEndpoint>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sso: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub issuer_url: Option<String>,
@@ -61,6 +63,7 @@ impl Endpoints {
             http: None,
             mqtt: None,
             mqtt_integration: None,
+            websocket_integration: None,
             sso: self.sso.clone(),
             api: self.api.clone(),
             console: self.console.clone(),

--- a/service-common/src/defaults.rs
+++ b/service-common/src/defaults.rs
@@ -6,6 +6,11 @@ pub fn enable_auth() -> bool {
 }
 
 #[inline]
+pub fn enable_api_keys() -> bool {
+    true
+}
+
+#[inline]
 pub fn realm() -> String {
     "drogue".into()
 }

--- a/service-common/src/endpoints.rs
+++ b/service-common/src/endpoints.rs
@@ -44,6 +44,8 @@ pub struct EndpointConfig {
     pub command_endpoint_url: Option<String>,
     #[serde(default)]
     kafka_bootstrap_servers: Option<String>,
+    #[serde(default)]
+    pub websocket_integration_url: Option<String>,
 
     #[serde(default)]
     pub local_certs: bool,
@@ -117,6 +119,12 @@ impl EndpointSource for EnvEndpointSource {
             .as_ref()
             .cloned()
             .map(|url| HttpEndpoint { url });
+        let websocket_integration = self
+            .0
+            .websocket_integration_url
+            .as_ref()
+            .cloned()
+            .map(|url| HttpEndpoint { url });
         let mqtt = self.0.mqtt_endpoint_host.as_ref().map(|host| MqttEndpoint {
             host: host.clone(),
             port: self.0.mqtt_endpoint_port,
@@ -150,6 +158,7 @@ impl EndpointSource for EnvEndpointSource {
             http,
             mqtt,
             mqtt_integration,
+            websocket_integration,
             sso,
             api,
             console,

--- a/websocket-integration/Cargo.toml
+++ b/websocket-integration/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "drogue-cloud-websocket-integration"
+version = "0.6.0"
+authors = ["Jb Trystram <jbtrystram@redhat.com>"]
+edition = "2018"
+license = "Apache-2.0"
+
+[dependencies]
+anyhow = "1"
+
+actix = { version = "0.12.0"}
+actix-http = "=3.0.0-beta.8"
+actix-web = "=4.0.0-beta.8"
+actix-web-actors = "=4.0.0-beta.6"
+actix-web-httpauth = "=0.6.0-beta.2"
+
+dotenv = "0.15"
+
+awc = "2"
+log = "0.4"
+env_logger = "0.8.4"
+futures = "0.3.1"
+bytes = "0.5.3"
+
+uuid = { version = "0.8", features = ["v4", "serde"] }
+reqwest = "0.11"
+
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+
+drogue-client = "0.7.0"
+drogue-cloud-service-common = { path = "../service-common" }
+drogue-cloud-integration-common = { path = "../integration-common" }
+drogue-cloud-service-api = { path = "../service-api" }

--- a/websocket-integration/Cargo.toml
+++ b/websocket-integration/Cargo.toml
@@ -28,6 +28,7 @@ reqwest = "0.11"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
+url = "2"
 
 drogue-client = "0.7.0"
 drogue-cloud-service-common = { path = "../service-common" }

--- a/websocket-integration/Dockerfile
+++ b/websocket-integration/Dockerfile
@@ -1,0 +1,7 @@
+FROM registry.access.redhat.com/ubi8-minimal
+
+LABEL org.opencontainers.image.source="https://github.com/drogue-iot/drogue-cloud"
+
+ADD target/release/drogue-cloud-websocket-integration /
+
+ENTRYPOINT [ "/drogue-cloud-websocket-integration" ]

--- a/websocket-integration/Makefile
+++ b/websocket-integration/Makefile
@@ -1,0 +1,4 @@
+CURRENT_DIR:=$(strip $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST)))))
+TOP_DIR := $(CURRENT_DIR)/..
+
+include ../Makefile

--- a/websocket-integration/TODO.md
+++ b/websocket-integration/TODO.md
@@ -1,0 +1,1 @@
+- Commands support : the client sends commands in the WS. 

--- a/websocket-integration/src/auth.rs
+++ b/websocket-integration/src/auth.rs
@@ -1,0 +1,113 @@
+use drogue_client::Context;
+use drogue_cloud_service_api::auth::user::authn::{AuthenticationRequest, Outcome};
+use drogue_cloud_service_api::auth::user::authz::{AuthorizationRequest, Permission};
+use drogue_cloud_service_api::auth::user::{authz, UserInformation};
+use drogue_cloud_service_common::client::UserAuthClient;
+use drogue_cloud_service_common::error::ServiceError;
+use drogue_cloud_service_common::openid::Authenticator;
+use std::sync::Arc;
+
+// Credentials can either be
+//  - username + API key
+//  - openID token
+pub enum Credentials {
+    Token(String),
+    ApiKey(UsernameAndApiKey),
+}
+
+pub struct UsernameAndApiKey {
+    pub username: String,
+    pub key: Option<String>,
+}
+
+impl Credentials {
+    pub async fn authenticate_and_authorize(
+        &self,
+        application: String,
+        authz: &Arc<UserAuthClient>,
+        auth: Authenticator,
+    ) -> Result<UserInformation, ServiceError> {
+        let authentication_result = self.authenticate(auth, authz).await?;
+
+        Credentials::authorize(application, &authentication_result, Permission::Read, authz)
+            .await
+            .map(|_| authentication_result)
+    }
+
+    async fn authenticate(
+        &self,
+        auth: Authenticator,
+        authz: &Arc<UserAuthClient>,
+    ) -> Result<UserInformation, ServiceError> {
+        match self {
+            Credentials::ApiKey(creds) => {
+                if creds.key.is_none() {
+                    log::debug!("Cannot authenticate : empty API key.");
+                    return Err(ServiceError::InvalidRequest(String::from(
+                        "No API key provided.",
+                    )));
+                }
+
+                let auth_response = authz
+                    .authenticate_api_key(
+                        AuthenticationRequest {
+                            user_id: creds.username.clone(),
+                            api_key: creds.key.clone().unwrap(),
+                        },
+                        Context::default(),
+                    )
+                    .await
+                    .map_err(|e| ServiceError::InternalError {
+                        message: e.to_string(),
+                    })?;
+                match auth_response.outcome {
+                    Outcome::Known(details) => Ok(UserInformation::Authenticated(details)),
+                    Outcome::Unknown => {
+                        log::debug!("Unknown API key");
+                        return Err(ServiceError::AuthenticationError);
+                    }
+                }
+            }
+            Credentials::Token(token) => match auth.validate_token(&token).await {
+                Ok(token) => Ok(UserInformation::Authenticated(token.into())),
+                Err(_) => Err(ServiceError::AuthenticationError),
+            },
+        }
+    }
+
+    async fn authorize(
+        application: String,
+        user: &UserInformation,
+        permission: Permission,
+        authz_client: &Arc<UserAuthClient>,
+    ) -> Result<(), ServiceError> {
+        log::debug!(
+            "Authorizing - user: {:?}, app: {}, permission: {:?}",
+            user,
+            application,
+            permission
+        );
+
+        let response = authz_client
+            .authorize(
+                AuthorizationRequest {
+                    application,
+                    permission,
+                    user_id: user.user_id().map(ToString::to_string),
+                    roles: user.roles().clone(),
+                },
+                Default::default(),
+            )
+            .await
+            .map_err(|e| ServiceError::InternalError {
+                message: e.to_string(),
+            })?;
+
+        log::debug!("Outcome: {:?}", response);
+
+        match response.outcome {
+            authz::Outcome::Allow => Ok(()),
+            authz::Outcome::Deny => Err(ServiceError::InvalidRequest(String::from("Unauthorized"))),
+        }
+    }
+}

--- a/websocket-integration/src/auth.rs
+++ b/websocket-integration/src/auth.rs
@@ -57,9 +57,7 @@ impl Credentials {
                         Context::default(),
                     )
                     .await
-                    .map_err(|e| ServiceError::InternalError {
-                        message: e.to_string(),
-                    })?;
+                    .map_err(|e| ServiceError::InternalError(e.to_string()))?;
                 match auth_response.outcome {
                     Outcome::Known(details) => Ok(UserInformation::Authenticated(details)),
                     Outcome::Unknown => {
@@ -99,9 +97,7 @@ impl Credentials {
                 Default::default(),
             )
             .await
-            .map_err(|e| ServiceError::InternalError {
-                message: e.to_string(),
-            })?;
+            .map_err(|e| ServiceError::InternalError(e.to_string()))?;
 
         log::debug!("Outcome: {:?}", response);
 

--- a/websocket-integration/src/main.rs
+++ b/websocket-integration/src/main.rs
@@ -111,7 +111,7 @@ async fn main() -> anyhow::Result<()> {
     // create and start the service actor
     let service_addr = Service {
         clients: HashMap::default(),
-        kafka_config: KafkaClientConfig::default(),
+        kafka_config: config.kafka,
         registry,
     }
     .start();

--- a/websocket-integration/src/main.rs
+++ b/websocket-integration/src/main.rs
@@ -32,8 +32,8 @@ pub struct Config {
     pub bind_addr: String,
     #[serde(default = "defaults::enable_auth")]
     pub enable_auth: bool,
-    #[serde(default)]
-    pub disable_api_keys: bool,
+    #[serde(default = "defaults::enable_api_keys")]
+    pub enable_api_keys: bool,
 
     #[serde(default)]
     pub health: HealthServerConfig,
@@ -94,7 +94,7 @@ async fn main() -> anyhow::Result<()> {
 
     let auth = web::Data::new(authenticator);
     let authz = web::Data::new(user_auth);
-    let enable_api_keys = web::Data::new(config.disable_api_keys);
+    let enable_api_keys = web::Data::new(config.enable_api_keys);
 
     let client = reqwest::Client::new();
     let registry = registry::v1::Client::new(

--- a/websocket-integration/src/main.rs
+++ b/websocket-integration/src/main.rs
@@ -1,0 +1,168 @@
+mod auth;
+mod messages;
+mod service;
+mod wshandler;
+
+use crate::wshandler::WsHandler;
+
+use dotenv::dotenv;
+
+use actix_web::web::Payload;
+use actix_web::{get, web, App, Either, Error, HttpRequest, HttpResponse, HttpServer};
+use actix_web_actors::ws;
+
+use actix_web_httpauth::extractors::basic::BasicAuth;
+use actix_web_httpauth::extractors::bearer::BearerAuth;
+
+use drogue_cloud_service_common::{
+    config::ConfigFromEnv, health::HealthServer, openid::Authenticator,
+};
+use drogue_cloud_service_common::{defaults, health::HealthServerConfig};
+use serde::Deserialize;
+
+use crate::auth::{Credentials, UsernameAndApiKey};
+use crate::service::Service;
+use actix::{Actor, Addr};
+use drogue_cloud_service_common::client::{UserAuthClient, UserAuthClientConfig};
+use drogue_cloud_service_common::error::ServiceError;
+use drogue_cloud_service_common::openid::TokenConfig;
+use futures::TryFutureExt;
+use std::sync::Arc;
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Config {
+    #[serde(default = "defaults::bind_addr")]
+    pub bind_addr: String,
+    #[serde(default = "defaults::enable_auth")]
+    pub enable_auth: bool,
+    #[serde(default)]
+    pub disable_api_keys: bool,
+
+    #[serde(default)]
+    pub health: HealthServerConfig,
+
+    user_auth: UserAuthClientConfig,
+}
+
+#[get("/stream/{application}")]
+pub async fn start_connection(
+    req: HttpRequest,
+    stream: Payload,
+    auth: web::Either<BearerAuth, BasicAuth>,
+    auth_client: web::Data<Option<Authenticator>>,
+    authz_client: web::Data<Option<Arc<UserAuthClient>>>,
+    authorize_api_keys: web::Data<bool>,
+    application: web::Path<String>,
+    service_address: web::Data<Addr<Service>>,
+) -> Result<HttpResponse, Error> {
+    let application = application.into_inner();
+
+    let auth_client = auth_client.get_ref().clone();
+    let authz_client = authz_client.get_ref().clone();
+
+    match (auth_client, authz_client) {
+        (Some(auth_client), Some(authz_client)) => {
+            let credentials = match auth {
+                Either::Left(bearer) => Ok(Credentials::Token(bearer.token().to_string())),
+                Either::Right(basic) => {
+                    if authorize_api_keys.get_ref().clone() {
+                        Ok(Credentials::ApiKey(UsernameAndApiKey {
+                            username: basic.user_id().to_string(),
+                            key: basic.password().map(|k| k.to_string()),
+                        }))
+                    } else {
+                        log::debug!("API keys authentication disabled");
+                        Err(ServiceError::InternalError {
+                            message: "API keys authentication disabled".to_string(),
+                        })
+                    }
+                }
+            }?;
+
+            // authentication
+            credentials
+                .authenticate_and_authorize(application.clone(), &authz_client, auth_client)
+                .await
+                .or(Err(ServiceError::AuthenticationError))?;
+        }
+        // authentication disabled
+        _ => {}
+    }
+
+    // launch web socket actor
+    let ws = WsHandler::new(application, service_address.get_ref().clone());
+    let resp = ws::start(ws, &req, stream)?;
+    Ok(resp)
+}
+
+#[actix_web::main]
+async fn main() -> anyhow::Result<()> {
+    env_logger::init();
+    dotenv().ok();
+
+    log::info!("Starting WebSocket integration service endpoint");
+
+    // Initialize config from environment variables
+    let config = Config::from_env().unwrap();
+
+    let enable_auth = config.enable_auth;
+
+    // set up security
+
+    let (authenticator, user_auth) = if enable_auth {
+        let client = reqwest::Client::new();
+        let authenticator = Authenticator::new().await?;
+        let user_auth = Arc::new(
+            UserAuthClient::from_config(
+                client,
+                config.user_auth,
+                TokenConfig::from_env_prefix("USER_AUTH")?.amend_with_env(),
+            )
+            .await?,
+        );
+        (Some(authenticator), Some(user_auth))
+    } else {
+        (None, None)
+    };
+
+    let auth = web::Data::new(authenticator);
+    let authz = web::Data::new(user_auth);
+    let enable_api_keys = web::Data::new(config.disable_api_keys);
+
+    // create and start the service actor
+    let service_addr = Service::default().start();
+    let service_addr = web::Data::new(service_addr);
+
+    // health server
+
+    let health = HealthServer::new(config.health, vec![]);
+
+    // main server
+
+    let main = HttpServer::new(move || {
+        // since we wrote our own auth service let's ignore this
+        // let bearer_auth = openid_auth!(req -> {
+        //     req
+        //     .app_data::<web::Data<Authenticator>>()
+        //     .as_ref()
+        //     .map(|d| d.as_ref())
+        // });
+
+        App::new()
+            .wrap(actix_web::middleware::Logger::default())
+            //.wrap(Condition::new(enable_auth, bearer_auth.clone()))
+            .app_data(service_addr.clone())
+            .app_data(auth.clone())
+            .app_data(authz.clone())
+            .app_data(enable_api_keys.clone())
+            .service(start_connection)
+    })
+    .bind(config.bind_addr)?
+    .run();
+
+    // run
+    futures::try_join!(health.run(), main.err_into())?;
+
+    // exiting
+    Ok(())
+}

--- a/websocket-integration/src/messages.rs
+++ b/websocket-integration/src/messages.rs
@@ -1,0 +1,23 @@
+use actix::prelude::{Message, Recipient};
+use uuid::Uuid;
+
+// Service sends the kafka events in this message to WSHandler
+#[derive(Message)]
+#[rtype(result = "()")]
+pub struct WsEvent(pub String);
+
+// WsHandler sends this to service to subscribe to the stream
+#[derive(Message)]
+#[rtype(result = "bool")]
+pub struct Subscribe {
+    pub addr: Recipient<WsEvent>,
+    pub application: String,
+    pub id: Uuid,
+}
+
+// WsHandler sends this to the service to disconnect from the stream
+#[derive(Message)]
+#[rtype(result = "()")]
+pub struct Disconnect {
+    pub id: Uuid,
+}

--- a/websocket-integration/src/messages.rs
+++ b/websocket-integration/src/messages.rs
@@ -1,4 +1,6 @@
 use actix::prelude::{Message, Recipient};
+use drogue_cloud_integration_common::stream::EventStream;
+use drogue_cloud_service_common::error::ServiceError;
 use uuid::Uuid;
 
 // Service sends the kafka events in this message to WSHandler
@@ -8,9 +10,10 @@ pub struct WsEvent(pub String);
 
 // WsHandler sends this to service to subscribe to the stream
 #[derive(Message)]
-#[rtype(result = "bool")]
+#[rtype(result = "()")]
 pub struct Subscribe {
     pub addr: Recipient<WsEvent>,
+    pub err_addr: Recipient<StreamError>,
     pub application: String,
     pub id: Uuid,
 }
@@ -19,5 +22,21 @@ pub struct Subscribe {
 #[derive(Message)]
 #[rtype(result = "()")]
 pub struct Disconnect {
+    pub id: Uuid,
+}
+
+// Service sends this to itself to run the stream
+#[derive(Message)]
+#[rtype(result = "()")]
+pub struct RunStream<'s> {
+    pub sub: Subscribe,
+    pub stream: EventStream<'s>,
+}
+
+// Service sends this to WSHandler if an error happens while subscribing or running the stream
+#[derive(Message)]
+#[rtype(result = "()")]
+pub struct StreamError {
+    pub error: ServiceError,
     pub id: Uuid,
 }

--- a/websocket-integration/src/messages.rs
+++ b/websocket-integration/src/messages.rs
@@ -15,6 +15,7 @@ pub struct Subscribe {
     pub addr: Recipient<WsEvent>,
     pub err_addr: Recipient<StreamError>,
     pub application: String,
+    pub consumer_group: Option<String>,
     pub id: Uuid,
 }
 

--- a/websocket-integration/src/route.rs
+++ b/websocket-integration/src/route.rs
@@ -42,7 +42,7 @@ pub async fn start_connection(
                         }))
                     } else {
                         log::debug!("API keys authentication disabled");
-                        Err(ServiceError::InternalError(
+                        Err(ServiceError::InvalidRequest(
                             "API keys authentication disabled".to_string(),
                         ))
                     }

--- a/websocket-integration/src/route.rs
+++ b/websocket-integration/src/route.rs
@@ -14,7 +14,7 @@ use drogue_cloud_service_common::client::UserAuthClient;
 use drogue_cloud_service_common::error::ServiceError;
 use drogue_cloud_service_common::openid::Authenticator;
 
-#[get("/stream/{application}")]
+#[get("/{application}")]
 pub async fn start_connection(
     req: HttpRequest,
     stream: Payload,

--- a/websocket-integration/src/route.rs
+++ b/websocket-integration/src/route.rs
@@ -1,0 +1,66 @@
+use crate::auth::{Credentials, UsernameAndApiKey};
+use crate::service::Service;
+use crate::wshandler::WsHandler;
+
+use actix::Addr;
+use actix_web::web::Payload;
+use actix_web::{get, web, Either, Error, HttpRequest, HttpResponse};
+use actix_web_actors::ws;
+use actix_web_httpauth::extractors::basic::BasicAuth;
+use actix_web_httpauth::extractors::bearer::BearerAuth;
+use std::sync::Arc;
+
+use drogue_cloud_service_common::client::UserAuthClient;
+use drogue_cloud_service_common::error::ServiceError;
+use drogue_cloud_service_common::openid::Authenticator;
+
+#[get("/stream/{application}")]
+pub async fn start_connection(
+    req: HttpRequest,
+    stream: Payload,
+    auth: web::Either<BearerAuth, BasicAuth>,
+    auth_client: web::Data<Option<Authenticator>>,
+    authz_client: web::Data<Option<Arc<UserAuthClient>>>,
+    authorize_api_keys: web::Data<bool>,
+    application: web::Path<String>,
+    service_addr: web::Data<Addr<Service>>,
+) -> Result<HttpResponse, Error> {
+    let application = application.into_inner();
+
+    let auth_client = auth_client.get_ref().clone();
+    let authz_client = authz_client.get_ref().clone();
+
+    match (auth_client, authz_client) {
+        (Some(auth_client), Some(authz_client)) => {
+            let credentials = match auth {
+                Either::Left(bearer) => Ok(Credentials::Token(bearer.token().to_string())),
+                Either::Right(basic) => {
+                    if authorize_api_keys.get_ref().clone() {
+                        Ok(Credentials::ApiKey(UsernameAndApiKey {
+                            username: basic.user_id().to_string(),
+                            key: basic.password().map(|k| k.to_string()),
+                        }))
+                    } else {
+                        log::debug!("API keys authentication disabled");
+                        Err(ServiceError::InternalError(
+                            "API keys authentication disabled".to_string(),
+                        ))
+                    }
+                }
+            }?;
+
+            // authentication
+            credentials
+                .authenticate_and_authorize(application.clone(), &authz_client, auth_client)
+                .await
+                .or(Err(ServiceError::AuthenticationError))?;
+        }
+        // authentication disabled
+        _ => {}
+    }
+
+    // launch web socket actor
+    let ws = WsHandler::new(application, service_addr.get_ref().clone());
+    let resp = ws::start(ws, &req, stream)?;
+    Ok(resp)
+}

--- a/websocket-integration/src/service.rs
+++ b/websocket-integration/src/service.rs
@@ -1,0 +1,178 @@
+use anyhow::Result;
+
+use actix::prelude::{Actor, Context, Handler, Recipient};
+
+use drogue_cloud_service_common::defaults;
+use serde::Deserialize;
+use std::collections::HashMap;
+
+use crate::messages::{Disconnect, Subscribe, WsEvent};
+use actix::{AsyncContext, ResponseFuture, SpawnHandle};
+use drogue_cloud_integration_common::stream::{EventStream, EventStreamConfig};
+
+use drogue_cloud_service_api::events::EventTarget;
+
+use futures::StreamExt;
+use uuid::Uuid;
+
+// Service Actor.
+// Read from the kafka and forwards messages to the Web socket actors
+pub struct Service {
+    clients: HashMap<Uuid, Stream>,
+    config: StreamerConfig,
+}
+
+impl Actor for Service {
+    type Context = Context<Self>;
+}
+
+impl Default for Service {
+    fn default() -> Service {
+        Service {
+            clients: HashMap::new(),
+            config: StreamerConfig::default(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct StreamerConfig {
+    #[serde(default = "defaults::kafka_bootstrap_servers")]
+    pub kafka_bootstrap_servers: String,
+    #[serde(default)]
+    pub kafka_properties: HashMap<String, String>,
+}
+
+impl Default for StreamerConfig {
+    fn default() -> Self {
+        Self {
+            kafka_bootstrap_servers: defaults::kafka_bootstrap_servers(),
+            kafka_properties: Default::default(),
+        }
+    }
+}
+
+pub struct Stream {
+    application: String,
+    runner: SpawnHandle,
+}
+
+/// Handle incoming messages from the WsHandler actor.
+impl Handler<Subscribe> for Service {
+    type Result = ResponseFuture<bool>;
+
+    fn handle(&mut self, msg: Subscribe, ctx: &mut Context<Self>) -> Self::Result {
+        let app = msg.application.clone();
+        let id = msg.id;
+        let addr = msg.addr.clone();
+        // set up a stream
+        let stream = Service::get_stream(
+            self.config.kafka_bootstrap_servers.clone(),
+            self.config.kafka_properties.clone(),
+            app.clone(),
+        );
+        match stream {
+            Ok(stream) => {
+                // run the stream in a subprocess
+                let fut = async move {
+                    // using _ because it's a while loop so a result isn't really expected
+                    let _ = Service::run_stream(stream, addr, app.clone().as_str()).await;
+                };
+                let fut = actix::fut::wrap_future::<_, Self>(fut);
+                let run_handle = ctx.spawn(fut);
+
+                // store the stream
+                self.clients.insert(
+                    id,
+                    Stream {
+                        application: msg.application.clone(),
+                        runner: run_handle,
+                    },
+                );
+                // subscribe was successful, respond true to the WsHandler
+                Box::pin(async move { true })
+            }
+            Err(_) => Box::pin(async move { false }),
+        }
+    }
+}
+
+impl Handler<Disconnect> for Service {
+    type Result = ();
+
+    fn handle(&mut self, msg: Disconnect, ctx: &mut Context<Self>) {
+        let stream = self.clients.remove(&msg.id);
+        match stream {
+            Some(s) => {
+                log::info!(
+                    "Disconnect message. Dropping stream for client [id: {}, app:{}]",
+                    msg.id,
+                    s.application
+                );
+                ctx.cancel_future(s.runner);
+            }
+            None => {
+                log::warn!("Received disconnect message for client [{}] but no stream was registered for it.", msg.id)
+            }
+        };
+    }
+}
+
+impl Service {
+    fn get_stream(
+        kafka_bootstrap_servers: String,
+        kafka_properties: HashMap<String, String>,
+        application: String,
+    ) -> Result<EventStream<'static>> {
+        // extract the shared named, which we use as kafka consumer group id
+        // TODO get group id
+        let group_id = None;
+
+        // log the request
+        log::debug!(
+            "Request to attach to app stream: {} (group: {:?})",
+            application,
+            group_id
+        );
+
+        // create stream
+        let stream = EventStream::new(EventStreamConfig {
+            bootstrap_servers: kafka_bootstrap_servers,
+            properties: kafka_properties,
+            target: EventTarget::Events(application.clone()),
+            consumer_group: group_id,
+        })
+        .map_err(|err| {
+            log::info!("Failed to subscribe to Kafka topic: {}", err);
+            err
+        })?;
+
+        // we started the stream, return it ...
+        log::info!("Subscribed to Kafka topic: {}", &application);
+        Ok(stream)
+    }
+
+    async fn run_stream(
+        mut stream: EventStream<'_>,
+        recipient: Recipient<WsEvent>,
+        application: &str,
+    ) -> Result<(), anyhow::Error> {
+        log::debug!("Running stream {:?}", application);
+
+        // run event stream
+        while let Some(event) = stream.next().await {
+            log::debug!("Topic: {} - Event: {:?}", application, event);
+
+            // Covert the event to a JSON string
+            let event = serde_json::to_string(&event?)?;
+            // Send the event as an Actor message. We don't really care if it fails
+            let _ = recipient.do_send(WsEvent(event.to_string()));
+
+            log::debug!("Sent message - go back to sleep");
+        }
+
+        Ok(())
+    }
+}
+
+// todo add tests

--- a/websocket-integration/src/wshandler.rs
+++ b/websocket-integration/src/wshandler.rs
@@ -1,0 +1,130 @@
+use crate::messages::{Disconnect, Subscribe, WsEvent};
+use crate::service::Service;
+use actix::prelude::*;
+use actix::{
+    fut, Actor, ActorContext, ActorFutureExt, Addr, AsyncContext, ContextFutureSpawner, Handler,
+    Running, WrapFuture,
+};
+use actix_web_actors::ws;
+use actix_web_actors::ws::Message::Text;
+use std::time::{Duration, Instant};
+use uuid::Uuid;
+
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
+const CLIENT_TIMEOUT: Duration = Duration::from_secs(10);
+
+// This is the actor handling one websocket connection.
+pub struct WsHandler {
+    // the topic to listen to
+    application: String,
+    // to exit the actor if the client was disconnected
+    heartbeat: Instant,
+    service_addr: Addr<Service>,
+    id: Uuid,
+}
+
+impl WsHandler {
+    pub fn new(app: String, service_addr: Addr<Service>) -> WsHandler {
+        WsHandler {
+            application: app,
+            heartbeat: Instant::now(),
+            service_addr,
+            id: Uuid::new_v4(),
+        }
+    }
+    fn heartbeat(&self, ctx: &mut ws::WebsocketContext<Self>) {
+        ctx.run_interval(HEARTBEAT_INTERVAL, |act, ctx| {
+            if Instant::now().duration_since(act.heartbeat) > CLIENT_TIMEOUT {
+                log::warn!("Disconnecting failed heartbeat");
+                ctx.stop();
+                return;
+            }
+
+            ctx.ping(b"PING");
+        });
+    }
+}
+
+// Implement actix Actor trait
+impl Actor for WsHandler {
+    type Context = ws::WebsocketContext<Self>;
+
+    fn started(&mut self, ctx: &mut Self::Context) {
+        log::info!("Starting WS handler");
+        self.heartbeat(ctx);
+
+        // Address of self, the WSHandler actor
+        let addr = ctx.address();
+        // Send a message to ask service to subscribe to Kafka stream.
+        self.service_addr
+            .send(Subscribe {
+                addr: addr.recipient(),
+                application: self.application.clone(),
+                id: self.id,
+            })
+            // We need to access the context when handling the future so we wrap it into an ActorFuture
+            .into_actor(self)
+            .then(|res, act, ctx| {
+                match res {
+                    Ok(_) => {
+                        log::info!("Subscribe request for {} successful", act.application);
+                    }
+                    _ => {
+                        log::error!("Subscribe request for {} failed", act.application);
+                        ctx.stop()
+                    }
+                };
+                fut::ready(())
+            })
+            .wait(ctx);
+    }
+
+    fn stopping(&mut self, _: &mut Self::Context) -> Running {
+        self.service_addr.do_send(Disconnect { id: self.id });
+        Running::Stop
+    }
+
+    fn stopped(&mut self, _: &mut Self::Context) {
+        log::debug!("Terminated WebSocket actor {}", self.id);
+    }
+}
+
+// Handle incoming messages from the Websocket Client
+impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WsHandler {
+    fn handle(&mut self, msg: Result<ws::Message, ws::ProtocolError>, ctx: &mut Self::Context) {
+        match msg {
+            Ok(ws::Message::Ping(msg)) => {
+                self.heartbeat = Instant::now();
+                ctx.pong(&msg);
+            }
+            Ok(ws::Message::Pong(_)) => {
+                self.heartbeat = Instant::now();
+            }
+            Ok(ws::Message::Binary(bin)) => ctx.binary(bin),
+            Ok(ws::Message::Close(reason)) => {
+                log::debug!("Client disconnected");
+                ctx.close(reason);
+                ctx.stop();
+            }
+            Ok(ws::Message::Continuation(_)) => {
+                ctx.stop();
+            }
+            Ok(ws::Message::Nop) => (),
+            Ok(Text(s)) => log::debug!("Recevied text from client in websocket :\n{}", s),
+            Err(e) => {
+                log::error!("WebSocket Protocol Error: {}", e);
+                ctx.stop()
+            }
+        }
+    }
+}
+
+// Handle incoming messages from the Service
+// Forward them to websocket Client
+impl Handler<WsEvent> for WsHandler {
+    type Result = ();
+
+    fn handle(&mut self, msg: WsEvent, ctx: &mut Self::Context) {
+        ctx.text(msg.0);
+    }
+}

--- a/websocket-integration/src/wshandler.rs
+++ b/websocket-integration/src/wshandler.rs
@@ -17,6 +17,8 @@ const CLIENT_TIMEOUT: Duration = Duration::from_secs(10);
 pub struct WsHandler {
     // the topic to listen to
     application: String,
+    // the optional consumer group
+    group_id: Option<String>,
     // to exit the actor if the client was disconnected
     heartbeat: Instant,
     service_addr: Addr<Service>,
@@ -24,9 +26,10 @@ pub struct WsHandler {
 }
 
 impl WsHandler {
-    pub fn new(app: String, service_addr: Addr<Service>) -> WsHandler {
+    pub fn new(app: String, group_id: Option<String>, service_addr: Addr<Service>) -> WsHandler {
         WsHandler {
             application: app,
+            group_id,
             heartbeat: Instant::now(),
             service_addr,
             id: Uuid::new_v4(),
@@ -62,6 +65,7 @@ impl Actor for WsHandler {
                 addr: addr,
                 err_addr: err_addr,
                 application: self.application.clone(),
+                consumer_group: self.group_id.clone(),
                 id: self.id,
             })
             // We need to access the context when handling the future so we wrap it into an ActorFuture

--- a/websocket-integration/src/wshandler.rs
+++ b/websocket-integration/src/wshandler.rs
@@ -112,7 +112,7 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WsHandler {
                 ctx.stop();
             }
             Ok(ws::Message::Nop) => (),
-            Ok(Text(s)) => log::debug!("Recevied text from client in websocket :\n{}", s),
+            Ok(Text(s)) => log::debug!("Received text from client {}:\n{}", self.id, s),
             Err(e) => {
                 log::error!("WebSocket Protocol Error: {}", e);
                 ctx.stop()


### PR DESCRIPTION
Here is an initial working implementation of a websocket service based on the actix actors framework. 


The endpoint is simple : `ws://url-to-service/{application}` where application is the app you wish to get the events from. 
When the socket is opened, events will get streamed: 
```
[~] websocat ws://websocket-integration.192.168.39.221.nip.io:30004/example-app -H="Authorization: Bearer "$(drg token)""

{"specversion":"1.0","id":"071ca963-25fe-4fca-ae54-8a7435842452","type":"io.drogue.event.v1","source":"drogue://example%2Dapp/device1","datacontenttype":"application/json","subject":"foo","time":"2021-08-10T12:41:12.865423747Z","data":{"temp":42},"partitionkey":"example%2Dapp/device1","device":"device1","application":"example-app","instance":"drogue"}

{"specversion":"1.0","id":"b4c4c1fd-7eeb-4aa3-adfd-c97a5d2af475","type":"io.drogue.event.v1","source":"drogue://example%2Dapp/device1","datacontenttype":"application/json","subject":"foo","time":"2021-08-10T12:41:14.923417613Z","data":{"temp":42},"device":"device1","partitionkey":"example%2Dapp/device1","application":"example-app","instance":"drogue"}
```

Both API keys and bearer tokens are supported : 
- bearer tokens use the `Authorisation: Bearer` header
- API keys use the `Authorisation: Basic` header, where password is the API token. 
 
Group ID is supported : You can optionally specify a group id for shared consumption: 
`ws://websocket-integration.192.168.39.221.nip.io:30004/example-app?group_id=<myGroup>`

There is one topic up for discussion : 
 - Commands support. We could use the other way of the web socket to send commands. Doing so requires a standardized payload. The MQTT integration uses topic name to extract /app/device/command. The websocket tunnel could use a JSON payload like : 
 ```
 {
 	device: <deviceID>
 	command: <commandName>
	payload: {}
 }
 ``` 
 I am omitting the application because the websocket is already targeting one.