### PR TITLE
Make deploy scripts cross-platform compatible

### DIFF
--- a/scripts/cmd/deploy.sh
+++ b/scripts/cmd/deploy.sh
@@ -32,64 +32,52 @@ Options:
 EOF
 }
 
-opts=$(getopt -o "mhkp:c:n:d:s:S:t:T" -- "$@")
 # shellcheck disable=SC2181
 [ $? -eq 0 ] || {
     help >&3
     # we don't "fail" but exit here, since we don't want any more output
     exit 1
 }
-eval set -- "$opts"
 
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-    -c)
-        CLUSTER="$2"
-        shift 2
+while getopts mhkp:c:n:d:s:S:t:T FLAG; do
+  case $FLAG in
+    c)
+        CLUSTER="$OPTARG"
         ;;
-    -k)
+    k)
         INSTALL_DEPS=false
-        shift
         ;;
-    -n)
-        DROGUE_NS="$2"
-        shift 2
+    n)
+        DROGUE_NS="$OPTARG"
         ;;
-    -s)
-        HELM_ARGS="$HELM_ARGS --set $2"
-        shift 2
+    s)
+        HELM_ARGS="$HELM_ARGS --set $OPTARG"
         ;;
-    -S)
-        HELM_ARGS="$HELM_ARGS --set-string $2"
-        shift 2
+    S)
+        HELM_ARGS="$HELM_ARGS --set-string $OPTARG"
         ;;
-    -d)
-        DOMAIN="$2"
-        shift 2
+    d)
+        DOMAIN="$OPTARG"
         ;;
-    -m)
+    m)
         MINIMIZE=true
-        shift
         ;;
-    -p)
-        HELM_PROFILE="$2"
-        shift 2
+    p)
+        HELM_PROFILE="$OPTARG"
         ;;
-    -t)
-        HELM_TIMEOUT="$2"
-        shift 2
+    t)
+        HELM_TIMEOUT="$OPTARG"
         ;;
-    -T)
+    T)
         DEPLOY_TWIN="true"
-        shift
         ;;
-    -h)
+    h)
         help >&3
         exit 0
         ;;
-    --)
-        shift
-        break
+    \?)
+        help >&3
+        exit 0
         ;;
     *)
         help >&3

--- a/scripts/drgadm
+++ b/scripts/drgadm
@@ -36,7 +36,7 @@ function on_exit() {
     rv=$?
     if [[ $rv != 0 && (! "$DEBUG") && -s "$LOG" ]]; then
         # if there was a failure, dump the full log
-        echo
+        echo 1>&2
         echo "Command failed:" 1>&2
         echo "----------------------" 1>&2
         cat "$LOG" 1>&2
@@ -53,7 +53,7 @@ trap on_exit EXIT
 
 # run the actual command
 if [[ "$DEBUG" ]]; then
-    source "$BASEDIR/cmd/${cmd}.sh" 3>&1
+    ( source "$BASEDIR/cmd/${cmd}.sh" ) 3>&1
 else
-    source "$BASEDIR/cmd/${cmd}.sh" 3>&1 &>"$LOG"
+    ( source "$BASEDIR/cmd/${cmd}.sh" ) 3>&1 &>"$LOG"
 fi


### PR DESCRIPTION
There were couple of things that made deployment scripts fail on OSX.

1. Bash 3.x kept using output redirection even after sourced script exited
2. The difference between bsd and linux version of `getopt`

This PR fixes both of these issues