### PR TITLE
Helm examples update

### DIFF
--- a/deploy/install/values.yaml
+++ b/deploy/install/values.yaml
@@ -1,2 +1,9 @@
 drogueCloudTwin:
   enabled: false
+
+drogueCloudExamples:
+  source:
+    kafka:
+      enabled: true
+    drogue:
+      enabled: false


### PR DESCRIPTION
This works in tandem with https://github.com/drogue-iot/drogue-cloud-helm-charts/pull/7 to make sure that examples uses kafka source when deployed in infra