### PR TITLE
create an app from the console

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4518,7 +4518,7 @@ checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
 [[package]]
 name = "patternfly-yew"
 version = "0.0.27"
-source = "git+https://github.com/jbtrystram/patternfly-yew?rev=4ceb7423a561e2319666a8e3c301943400cc505e#4ceb7423a561e2319666a8e3c301943400cc505e"
+source = "git+https://github.com/ctron/patternfly-yew?rev=a65d37c50adb5ea75d4125c8c835f92873ea87ab#a65d37c50adb5ea75d4125c8c835f92873ea87ab"
 dependencies = [
  "chrono",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1961,6 +1961,7 @@ dependencies = [
  "drogue-cloud-service-api",
  "env_logger 0.7.1",
  "headers",
+ "hostname-validator",
  "http",
  "indexmap",
  "itertools 0.9.0",
@@ -3256,6 +3257,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname-validator"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be14a194c8bc9f0ce9901de058cf114bab6ae85d461adc4bfa37deb295ad89d4"
+
+[[package]]
 name = "http"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4511,7 +4518,7 @@ checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
 [[package]]
 name = "patternfly-yew"
 version = "0.0.27"
-source = "git+https://github.com/ctron/patternfly-yew?rev=21660fc7849cb9fc29fc85493ee6b0bb389707b6#21660fc7849cb9fc29fc85493ee6b0bb389707b6"
+source = "git+https://github.com/jbtrystram/patternfly-yew?rev=4ceb7423a561e2319666a8e3c301943400cc505e#4ceb7423a561e2319666a8e3c301943400cc505e"
 dependencies = [
  "chrono",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ members = [
 [patch.crates-io]
 testcontainers = { git = "https://github.com/testcontainers/testcontainers-rs", rev = "fe51e06fb2c44b1d3e3fd627cedea3fd582487ef" }
 
-patternfly-yew = { git = "https://github.com/ctron/patternfly-yew", rev = "21660fc7849cb9fc29fc85493ee6b0bb389707b6" } # FIXME: awaiting release
+patternfly-yew = { git = "https://github.com/jbtrystram/patternfly-yew", rev = "4ceb7423a561e2319666a8e3c301943400cc505e" } # FIXME: awaiting release
 #patternfly-yew = { path = "../patternfly-yew" }
 
 #reqwest = { git = "https://github.com/ctron/reqwest", branch = "feature/basic_auth_wasm_1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ members = [
 [patch.crates-io]
 testcontainers = { git = "https://github.com/testcontainers/testcontainers-rs", rev = "fe51e06fb2c44b1d3e3fd627cedea3fd582487ef" }
 
-patternfly-yew = { git = "https://github.com/jbtrystram/patternfly-yew", rev = "4ceb7423a561e2319666a8e3c301943400cc505e" } # FIXME: awaiting release
+patternfly-yew = { git = "https://github.com/ctron/patternfly-yew", rev = "a65d37c50adb5ea75d4125c8c835f92873ea87ab" } # FIXME: awaiting release
 #patternfly-yew = { path = "../patternfly-yew" }
 
 #reqwest = { git = "https://github.com/ctron/reqwest", branch = "feature/basic_auth_wasm_1" }

--- a/console-frontend/Cargo.toml
+++ b/console-frontend/Cargo.toml
@@ -59,6 +59,8 @@ base64 = "0.13"
 itertools = "0.9"
 percent-encoding = "2.1"
 
+hostname-validator = "1.1.0"
+
 indexmap = "1.7.0"
 uuid = { version = "0.8", features = ["wasm-bindgen", "v4"] }
 

--- a/console-frontend/src/pages/apps/create.rs
+++ b/console-frontend/src/pages/apps/create.rs
@@ -1,0 +1,123 @@
+use crate::error::{ErrorNotification, ErrorNotifier};
+use crate::{backend::Backend, error::error};
+use patternfly_yew::*;
+use yew::{format::*, prelude::*, services::fetch::*};
+
+use serde_json::json;
+
+#[derive(Clone, PartialEq, Properties)]
+pub struct Props {
+    pub backend: Backend,
+    pub on_close: Callback<()>,
+}
+
+pub enum Msg {
+    Success,
+    Error(ErrorNotification),
+    Create,
+    NewAppName(String),
+}
+
+pub struct CreateDialog {
+    props: Props,
+    link: ComponentLink<Self>,
+
+    new_app_name: String,
+
+    fetch_task: Option<FetchTask>,
+}
+
+impl Component for CreateDialog {
+    type Message = Msg;
+    type Properties = Props;
+
+    fn create(props: Self::Properties, link: ComponentLink<Self>) -> Self {
+        Self {
+            props,
+            link,
+            fetch_task: None,
+            new_app_name: Default::default(),
+        }
+    }
+
+    fn update(&mut self, msg: Self::Message) -> ShouldRender {
+        match msg {
+            Msg::Error(msg) => {
+                BackdropDispatcher::default().close();
+                msg.toast();
+            }
+            Msg::Create => match self.create(self.new_app_name.clone()) {
+                Ok(task) => self.fetch_task = Some(task),
+                Err(err) => error("Failed to create", err),
+            },
+            Msg::Success => {
+                self.props.on_close.emit(());
+                BackdropDispatcher::default().close()
+            }
+            Msg::NewAppName(name) => self.new_app_name = name,
+        };
+        true
+    }
+
+    fn change(&mut self, _props: Self::Properties) -> ShouldRender {
+        true
+    }
+
+    fn view(&self) -> Html {
+        let is_valid = hostname_validator::is_valid(self.new_app_name.as_str());
+        let v = |value: &str| match hostname_validator::is_valid(value) {
+            false => InputState::Error,
+            true => InputState::Default,
+        };
+
+        return html! {
+            <>
+            <Bullseye plain=true>
+            <Modal
+                title = {"Create an application"}
+                variant= ModalVariant::Small
+                footer = {html!{<>
+                                <button class="pf-c-button pf-m-primary"
+                                disabled=!is_valid || self.fetch_task.is_some()
+                                type="button"
+                                onclick=self.link.callback(|_|Msg::Create) >
+                                    {"Create"}</button>
+                         </>}}
+            >
+                <Form>
+                       <FormGroup>
+                            <TextInput
+                                validator=Validator::from(v)
+                                onchange=self.link.callback(|app|Msg::NewAppName(app))
+                                placeholder="Application ID"/>
+                        </FormGroup>
+                </Form>
+            </Modal>
+            </Bullseye>
+            </>
+        };
+    }
+}
+
+impl CreateDialog {
+    fn create(&self, name: String) -> Result<FetchTask, anyhow::Error> {
+        let payload = json!({
+        "metadata": {
+            "name": name,
+        },
+        "spec": {},
+        });
+
+        self.props.backend.info.request(
+            Method::POST,
+            "/api/registry/v1alpha1/apps",
+            Json(&payload),
+            vec![("Content-Type", "application/json")],
+            self.link
+                .callback(move |response: Response<Text>| match response.status() {
+                    StatusCode::CREATED => Msg::Success,
+                    _ => Msg::Error(response.notify("Failed to create")),
+                }),
+        )
+    }
+}

--- a/console-frontend/src/pages/apps/index.rs
+++ b/console-frontend/src/pages/apps/index.rs
@@ -75,6 +75,7 @@ pub struct Index {
     entries: Vec<ApplicationEntry>,
 
     new_app_name: String,
+    new_app_name_is_valid: bool,
 
     fetch_task: Option<FetchTask>,
 }
@@ -91,6 +92,7 @@ impl Component for Index {
             entries: Vec::new(),
             fetch_task: None,
             new_app_name: Default::default(),
+            new_app_name_is_valid: false,
         }
     }
 
@@ -128,7 +130,10 @@ impl Component for Index {
                 BackdropDispatcher::default().close();
                 self.new_app_name = Default::default();
             }
-            Msg::NewAppName(name) => self.new_app_name = name,
+            Msg::NewAppName(name) => {
+                self.new_app_name_is_valid = hostname_validator::is_valid(name.as_str());
+                self.new_app_name = name
+            }
         };
         true
     }
@@ -259,7 +264,9 @@ impl Index {
                 variant= ModalVariant::Small
                 footer = {html!{<>
                                 <button class="pf-c-button pf-m-primary"
-                                disabled=!hostname_validator::is_valid(self.new_app_name.as_str())
+                                // fixme this does not work because this code is not refreshed
+                                // by the view() method. It's called once, when the modal is opened.
+                               // disabled=!self.new_app_name_is_valid
                                 type="button"
                                 onclick=self.link.callback(|_|Msg::Create) >
                                     {"Create"}</button>

--- a/console-frontend/src/pages/apps/mod.rs
+++ b/console-frontend/src/pages/apps/mod.rs
@@ -1,7 +1,9 @@
+mod create;
 mod details;
 mod index;
 pub mod ownership;
 
+pub use create::*;
 pub use details::*;
 pub use index::*;
 


### PR DESCRIPTION
Add a button and a modal to create an application from the "Applications" page of the console
![image](https://user-images.githubusercontent.com/12406409/142406974-5be1a96a-89ee-4f6e-8a02-606ccfcec231.png)

The dialog will not accept non compliant values (hostnames, RFC 1123)
![image](https://user-images.githubusercontent.com/12406409/142407103-f0fea3db-e730-46dd-aacc-ee6b4ff3fa29.png)

![image](https://user-images.githubusercontent.com/12406409/142438517-73ff72c8-01b1-4ffb-bfea-4e48c1b82ad9.png)

When create is clicked, the modal is dismissed and the app created