### PR TITLE
Console : admin tab improvements

### DIFF
--- a/console-frontend/src/pages/apps/details/admin.rs
+++ b/console-frontend/src/pages/apps/details/admin.rs
@@ -190,7 +190,7 @@ impl Component for Admin {
 
     fn change(&mut self, props: Self::Properties) -> ShouldRender {
         if self.stop {
-            true
+            false
         } else if self.props != props {
             self.props = props;
             true
@@ -425,7 +425,7 @@ impl Admin {
                             Err(err) => Msg::Error(err.notify("Failed to fetch transfer state")),
                         },
                         StatusCode::NO_CONTENT => Msg::TransferPending(None),
-                        _ => Msg::Error(response.notify("Failed to fetch transfer state")),
+                        _ => Msg::Stop("Failed to fetch transfer state".to_string()),
                     }
                 }),
         )

--- a/console-frontend/src/pages/apps/details/mod.rs
+++ b/console-frontend/src/pages/apps/details/mod.rs
@@ -165,16 +165,17 @@ impl Details {
             ),
             self.props.backend.info.request(
                 Method::GET,
-                format!("/api/admin/v1alpha1/apps/{}", url_encode(&self.props.name)),
+                format!(
+                    "/api/admin/v1alpha1/apps/{}/members",
+                    url_encode(&self.props.name)
+                ),
                 Nothing,
                 vec![],
-                self.link.callback(move |response: Response<Text>| {
-                    log::warn!("members callback is {:?}", response);
-                    match response.status() {
+                self.link
+                    .callback(move |response: Response<Text>| match response.status() {
                         status if status.is_success() => Msg::SetAdmin(true),
                         _ => Msg::SetAdmin(false),
-                    }
-                }),
+                    }),
             ),
         )
     }


### PR DESCRIPTION
When an user that is not an admin loads the admin tab, the app no longer crashes . 
It simply displays an empty page with a couple of errors messages. 

Hiding the admin tab if the user is not admin : 
![image](https://user-images.githubusercontent.com/12406409/143016062-d0799b7a-80d9-40d6-8192-a8d49a8f8fe4.png)


If a transfer is already pending a short message is added 
![image](https://user-images.githubusercontent.com/12406409/143015756-bf2be2ce-11b3-4a9e-9e67-6b2301e6c548.png)

No display of the transfer box if the user if not the owner. 
![image](https://user-images.githubusercontent.com/12406409/143015925-96d2f827-ece2-4d8e-88fc-0883c15cc418.png)

orce load the admin tab by typing the URL 
![image](https://user-images.githubusercontent.com/12406409/143016222-b9899677-d66b-414d-b971-bccc8841756b.png)
 