### PR TITLE
Use HTTP URL for submodule as it doesn't require login to github

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "helm-charts"]
 	path = deploy/helm
-	url = git@github.com:drogue-iot/drogue-cloud-helm-charts.git
+	url = https://github.com/drogue-iot/drogue-cloud-helm-charts.git


### PR DESCRIPTION
Noticed this while testing on a new VM the other day ... git:// URL will ask you to be logged in, while https one is not