### PR TITLE
Use relative URL for submodule(s)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "helm-charts"]
 	path = deploy/helm
-	url = git@github.com:drogue-iot/drogue-cloud-helm-charts.git
+	url = ../drogue-cloud-helm-charts.git


### PR DESCRIPTION
I think I found an elegant solution for ssh/https submodules "issue". It seems that relative paths work well for defining the submodules and they will respect the protocol that was used for cloning. So it should work properly for both use cases.