### PR TITLE
docs: add the description field for the create token operation in API documentation

### DIFF
--- a/console-backend/api/index.yaml
+++ b/console-backend/api/index.yaml
@@ -96,6 +96,13 @@ paths:
       description: Create a new access tokens for this user.
       tags:
         - Access Token
+      parameters:
+        - name: description
+          required: false
+          in: query
+          description: A description to attach to the token entry.
+          schema:
+            type: string
       responses:
         "200":
           description: A new access token was created.


### PR DESCRIPTION
This is implemented but was not documented : https://github.com/drogue-iot/drogue-cloud/blob/3cc16a787b6bed518f30fd357302026d008ba1a1/service-api/src/token.rs#L21-L23