### PR TITLE
Add support for metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2198,6 +2198,7 @@ dependencies = [
  "ntex-rt",
  "ntex-service",
  "openssl",
+ "prometheus",
  "reqwest",
  "rustls 0.20.2",
  "serde 1.0.130",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2045,12 +2045,14 @@ dependencies = [
  "futures-util",
  "headers",
  "http",
+ "lazy_static 1.4.0",
  "log",
  "mime",
  "ntex",
  "openid",
  "openssl",
  "percent-encoding",
+ "prometheus",
  "rand 0.8.4",
  "rdkafka",
  "reqwest",
@@ -4319,9 +4321,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-src"
-version = "111.16.0+1.1.1l"
+version = "111.17.0+1.1.1m"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab2173f69416cf3ec12debb5823d244127d23a9b127d5a5189aa97c5fa2859f"
+checksum = "05d6a336abd10814198f66e2a91ccd7336611f30334119ca8ce300536666fcf4"
 dependencies = [
  "cc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,6 +441,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-web-prom"
+version = "0.6.0-beta.1"
+source = "git+https://github.com/nlopes/actix-web-prom?rev=41a3ff87a3f2bcf30a89474c149c119b30a02880#41a3ff87a3f2bcf30a89474c149c119b30a02880"
+dependencies = [
+ "actix-web",
+ "futures",
+ "pin-project 1.0.8",
+ "prometheus",
+]
+
+[[package]]
 name = "actix_derive"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2079,6 +2090,7 @@ dependencies = [
  "actix-rt 2.6.0",
  "actix-tls",
  "actix-web",
+ "actix-web-prom",
  "anyhow",
  "async-trait",
  "chrono",
@@ -2100,6 +2112,7 @@ dependencies = [
  "openid",
  "openssl",
  "percent-encoding",
+ "prometheus",
  "reqwest",
  "rustls 0.20.2",
  "serde 1.0.130",
@@ -2398,6 +2411,7 @@ dependencies = [
  "actix-service 2.0.0",
  "actix-web",
  "actix-web-httpauth",
+ "actix-web-prom",
  "anyhow",
  "async-std",
  "async-trait",
@@ -2421,6 +2435,7 @@ dependencies = [
  "ntex",
  "openid",
  "pem 1.0.0",
+ "prometheus",
  "reqwest",
  "rustls 0.20.2",
  "serde 1.0.130",
@@ -4680,6 +4695,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5986aa8d62380092d2f50f8b1cdba9cb9b6731ffd4b25b51fd126b6c3e05b99c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "fnv",
+ "lazy_static 1.4.0",
+ "memchr",
+ "parking_lot",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,7 @@ dependencies = [
  "actix-web",
  "futures",
  "pin-project 1.0.8",
- "prometheus 0.13.0",
+ "prometheus",
 ]
 
 [[package]]
@@ -1812,7 +1812,7 @@ dependencies = [
  "log",
  "native-tls",
  "pem 1.0.0",
- "prometheus 0.13.0",
+ "prometheus",
  "rstest",
  "rustls 0.20.2",
  "rustls-pemfile",
@@ -1850,7 +1850,7 @@ dependencies = [
  "futures",
  "http",
  "log",
- "prometheus 0.13.0",
+ "prometheus",
  "regex",
  "serde 1.0.130",
  "serde_json",
@@ -1883,7 +1883,7 @@ dependencies = [
  "futures-util",
  "jsonwebtokens",
  "log",
- "prometheus 0.13.0",
+ "prometheus",
  "reqwest",
  "serde 1.0.130",
  "serde_json",
@@ -1924,7 +1924,7 @@ dependencies = [
  "log",
  "mime",
  "openid",
- "prometheus 0.13.0",
+ "prometheus",
  "reqwest",
  "ring",
  "serde 1.0.130",
@@ -2010,6 +2010,7 @@ dependencies = [
  "openid",
  "pem 1.0.0",
  "pin-project 1.0.8",
+ "prometheus",
  "rand 0.7.3",
  "reqwest",
  "rust-crypto",
@@ -2056,7 +2057,7 @@ dependencies = [
  "openid",
  "openssl",
  "percent-encoding",
- "prometheus 0.12.0",
+ "prometheus",
  "rand 0.8.4",
  "rdkafka",
  "reqwest",
@@ -2118,7 +2119,7 @@ dependencies = [
  "openid",
  "openssl",
  "percent-encoding",
- "prometheus 0.13.0",
+ "prometheus",
  "reqwest",
  "rustls 0.20.2",
  "serde 1.0.130",
@@ -2202,7 +2203,7 @@ dependencies = [
  "ntex-rt",
  "ntex-service",
  "openssl",
- "prometheus 0.13.0",
+ "prometheus",
  "reqwest",
  "rustls 0.20.2",
  "serde 1.0.130",
@@ -2244,7 +2245,7 @@ dependencies = [
  "ntex-service",
  "openid",
  "openssl",
- "prometheus 0.13.0",
+ "prometheus",
  "reqwest",
  "rustls 0.19.1",
  "serde 1.0.130",
@@ -2309,7 +2310,7 @@ dependencies = [
  "humantime-serde",
  "indexmap",
  "log",
- "prometheus 0.13.0",
+ "prometheus",
  "reqwest",
  "serde 1.0.130",
  "serde_json",
@@ -2444,7 +2445,7 @@ dependencies = [
  "ntex",
  "openid",
  "pem 1.0.0",
- "prometheus 0.13.0",
+ "prometheus",
  "reqwest",
  "rustls 0.20.2",
  "serde 1.0.130",
@@ -2490,7 +2491,7 @@ dependencies = [
  "humantime 2.1.0",
  "humantime-serde",
  "log",
- "prometheus 0.13.0",
+ "prometheus",
  "rdkafka",
  "reqwest",
  "serde 1.0.130",
@@ -2526,7 +2527,7 @@ dependencies = [
  "kube-runtime",
  "log",
  "operator-framework",
- "prometheus 0.13.0",
+ "prometheus",
  "reqwest",
  "serde 1.0.130",
  "serde_json",
@@ -2563,7 +2564,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "log",
  "maplit",
- "prometheus 0.13.0",
+ "prometheus",
  "rand 0.7.3",
  "reqwest",
  "rust-crypto",
@@ -2603,7 +2604,7 @@ dependencies = [
  "futures-util",
  "log",
  "native-tls",
- "prometheus 0.13.0",
+ "prometheus",
  "rustls 0.20.2",
  "serde 1.0.130",
  "serde_json",
@@ -2635,7 +2636,7 @@ dependencies = [
  "env_logger 0.8.4",
  "futures",
  "log",
- "prometheus 0.13.0",
+ "prometheus",
  "reqwest",
  "serde 1.0.130",
  "serde_json",
@@ -4709,20 +4710,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
 dependencies = [
  "unicode-xid",
-]
-
-[[package]]
-name = "prometheus"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5986aa8d62380092d2f50f8b1cdba9cb9b6731ffd4b25b51fd126b6c3e05b99c"
-dependencies = [
- "cfg-if 1.0.0",
- "fnv",
- "lazy_static 1.4.0",
- "memchr",
- "parking_lot",
- "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,13 +442,13 @@ dependencies = [
 
 [[package]]
 name = "actix-web-prom"
-version = "0.6.0-beta.1"
-source = "git+https://github.com/nlopes/actix-web-prom?rev=41a3ff87a3f2bcf30a89474c149c119b30a02880#41a3ff87a3f2bcf30a89474c149c119b30a02880"
+version = "0.6.0-beta.4"
+source = "git+https://github.com/nlopes/actix-web-prom?branch=nlopes/bump-to-actix-web-14#d9fdf591ebf67458855fcc2d1b57a5b408e2ae64"
 dependencies = [
  "actix-web",
  "futures",
  "pin-project 1.0.8",
- "prometheus",
+ "prometheus 0.13.0",
 ]
 
 [[package]]
@@ -1812,6 +1812,7 @@ dependencies = [
  "log",
  "native-tls",
  "pem 1.0.0",
+ "prometheus 0.13.0",
  "rstest",
  "rustls 0.20.2",
  "rustls-pemfile",
@@ -1849,6 +1850,7 @@ dependencies = [
  "futures",
  "http",
  "log",
+ "prometheus 0.13.0",
  "regex",
  "serde 1.0.130",
  "serde_json",
@@ -1881,6 +1883,7 @@ dependencies = [
  "futures-util",
  "jsonwebtokens",
  "log",
+ "prometheus 0.13.0",
  "reqwest",
  "serde 1.0.130",
  "serde_json",
@@ -1921,6 +1924,7 @@ dependencies = [
  "log",
  "mime",
  "openid",
+ "prometheus 0.13.0",
  "reqwest",
  "ring",
  "serde 1.0.130",
@@ -2052,7 +2056,7 @@ dependencies = [
  "openid",
  "openssl",
  "percent-encoding",
- "prometheus",
+ "prometheus 0.12.0",
  "rand 0.8.4",
  "rdkafka",
  "reqwest",
@@ -2114,7 +2118,7 @@ dependencies = [
  "openid",
  "openssl",
  "percent-encoding",
- "prometheus",
+ "prometheus 0.13.0",
  "reqwest",
  "rustls 0.20.2",
  "serde 1.0.130",
@@ -2198,7 +2202,7 @@ dependencies = [
  "ntex-rt",
  "ntex-service",
  "openssl",
- "prometheus",
+ "prometheus 0.13.0",
  "reqwest",
  "rustls 0.20.2",
  "serde 1.0.130",
@@ -2240,6 +2244,7 @@ dependencies = [
  "ntex-service",
  "openid",
  "openssl",
+ "prometheus 0.13.0",
  "reqwest",
  "rustls 0.19.1",
  "serde 1.0.130",
@@ -2304,6 +2309,7 @@ dependencies = [
  "humantime-serde",
  "indexmap",
  "log",
+ "prometheus 0.13.0",
  "reqwest",
  "serde 1.0.130",
  "serde_json",
@@ -2438,7 +2444,7 @@ dependencies = [
  "ntex",
  "openid",
  "pem 1.0.0",
- "prometheus",
+ "prometheus 0.13.0",
  "reqwest",
  "rustls 0.20.2",
  "serde 1.0.130",
@@ -2484,6 +2490,7 @@ dependencies = [
  "humantime 2.1.0",
  "humantime-serde",
  "log",
+ "prometheus 0.13.0",
  "rdkafka",
  "reqwest",
  "serde 1.0.130",
@@ -2519,6 +2526,7 @@ dependencies = [
  "kube-runtime",
  "log",
  "operator-framework",
+ "prometheus 0.13.0",
  "reqwest",
  "serde 1.0.130",
  "serde_json",
@@ -2555,6 +2563,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "log",
  "maplit",
+ "prometheus 0.13.0",
  "rand 0.7.3",
  "reqwest",
  "rust-crypto",
@@ -2594,6 +2603,7 @@ dependencies = [
  "futures-util",
  "log",
  "native-tls",
+ "prometheus 0.13.0",
  "rustls 0.20.2",
  "serde 1.0.130",
  "serde_json",
@@ -2625,6 +2635,7 @@ dependencies = [
  "env_logger 0.8.4",
  "futures",
  "log",
+ "prometheus 0.13.0",
  "reqwest",
  "serde 1.0.130",
  "serde_json",
@@ -4705,6 +4716,20 @@ name = "prometheus"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5986aa8d62380092d2f50f8b1cdba9cb9b6731ffd4b25b51fd126b6c3e05b99c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "fnv",
+ "lazy_static 1.4.0",
+ "memchr",
+ "parking_lot",
+ "thiserror",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f64969ffd5dd8f39bd57a68ac53c163a095ed9d0fb707146da1b27025a3504"
 dependencies = [
  "cfg-if 1.0.0",
  "fnv",

--- a/authentication-service/Cargo.toml
+++ b/authentication-service/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1"
 
 actix-web = "=4.0.0-beta.19" # we need v4 as we need tokio 1
 actix-web-httpauth = "=0.6.0-beta.7"
+prometheus = { version = "^0.13", default-features = false }
 
 tokio = { version = "1", features = ["full"] }
 

--- a/authentication-service/src/lib.rs
+++ b/authentication-service/src/lib.rs
@@ -97,7 +97,11 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     // run
 
     if let Some(health) = config.health {
-        let health = HealthServer::new(health, vec![Box::new(data_service)], None);
+        let health = HealthServer::new(
+            health,
+            vec![Box::new(data_service)],
+            Some(prometheus::default_registry().clone()),
+        );
         futures::try_join!(health.run(), main.err_into())?;
     } else {
         futures::try_join!(main)?;

--- a/authentication-service/src/lib.rs
+++ b/authentication-service/src/lib.rs
@@ -97,7 +97,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     // run
 
     if let Some(health) = config.health {
-        let health = HealthServer::new(health, vec![Box::new(data_service)]);
+        let health = HealthServer::new(health, vec![Box::new(data_service)], None);
         futures::try_join!(health.run(), main.err_into())?;
     } else {
         futures::try_join!(main)?;

--- a/coap-endpoint/Cargo.toml
+++ b/coap-endpoint/Cargo.toml
@@ -30,6 +30,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_urlencoded= "^0.7"
 tokio = "1.7"
+prometheus = { version = "^0.13", default-features = false }
 
 [dev-dependencies]
 url = "2.2"

--- a/coap-endpoint/src/lib.rs
+++ b/coap-endpoint/src/lib.rs
@@ -258,7 +258,11 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     )?;
 
     if let Some(health) = config.health {
-        let health = HealthServer::new(health, vec![Box::new(command_source)], None);
+        let health = HealthServer::new(
+            health,
+            vec![Box::new(command_source)],
+            Some(prometheus::default_registry().clone()),
+        );
         futures::try_join!(health.run(), device_to_endpoint.err_into())?;
     } else {
         futures::try_join!(device_to_endpoint)?;

--- a/coap-endpoint/src/lib.rs
+++ b/coap-endpoint/src/lib.rs
@@ -258,7 +258,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     )?;
 
     if let Some(health) = config.health {
-        let health = HealthServer::new(health, vec![Box::new(command_source)]);
+        let health = HealthServer::new(health, vec![Box::new(command_source)], None);
         futures::try_join!(health.run(), device_to_endpoint.err_into())?;
     } else {
         futures::try_join!(device_to_endpoint)?;

--- a/command-endpoint/Cargo.toml
+++ b/command-endpoint/Cargo.toml
@@ -14,6 +14,8 @@ actix-web = "=4.0.0-beta.19" # we need v4 as we need tokio 1
 actix-web-httpauth = "=0.6.0-beta.7"
 actix-cors = "=0.6.0-beta.8"
 
+prometheus = { version = "^0.13", default-features = false }
+
 async-trait = "0.1"
 futures = "0.3"
 futures-core = "0.3"

--- a/command-endpoint/src/lib.rs
+++ b/command-endpoint/src/lib.rs
@@ -121,7 +121,8 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     // run
 
     if let Some(health) = config.health {
-        let health = HealthServer::new(health, vec![], None);
+        let health =
+            HealthServer::new(health, vec![], Some(prometheus::default_registry().clone()));
         futures::try_join!(health.run(), main.err_into())?;
     } else {
         futures::try_join!(main)?;

--- a/command-endpoint/src/lib.rs
+++ b/command-endpoint/src/lib.rs
@@ -121,7 +121,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     // run
 
     if let Some(health) = config.health {
-        let health = HealthServer::new(health, vec![]);
+        let health = HealthServer::new(health, vec![], None);
         futures::try_join!(health.run(), main.err_into())?;
     } else {
         futures::try_join!(main)?;

--- a/console-backend/Cargo.toml
+++ b/console-backend/Cargo.toml
@@ -13,6 +13,7 @@ actix-web = "=4.0.0-beta.19" # we need v4 as we need tokio 1
 actix-cors = "=0.6.0-beta.8"
 actix-web-httpauth = "=0.6.0-beta.7"
 tokio-stream = { version = "0.1", features = ["time"] }
+prometheus = { version = "^0.13", default-features = false }
 
 openid = "0.9"
 biscuit = "0.5"

--- a/console-backend/src/lib.rs
+++ b/console-backend/src/lib.rs
@@ -268,7 +268,7 @@ pub async fn run(config: Config, endpoints: Endpoints) -> anyhow::Result<()> {
     // run
 
     if let Some(health) = config.health {
-        let health = HealthServer::new(health, vec![]);
+        let health = HealthServer::new(health, vec![], None);
         futures::try_join!(health.run(), main.err_into())?;
     } else {
         futures::try_join!(main)?;

--- a/console-backend/src/lib.rs
+++ b/console-backend/src/lib.rs
@@ -268,7 +268,8 @@ pub async fn run(config: Config, endpoints: Endpoints) -> anyhow::Result<()> {
     // run
 
     if let Some(health) = config.health {
-        let health = HealthServer::new(health, vec![], None);
+        let health =
+            HealthServer::new(health, vec![], Some(prometheus::default_registry().clone()));
         futures::try_join!(health.run(), main.err_into())?;
     } else {
         futures::try_join!(main)?;

--- a/deploy/install/Chart.yaml
+++ b/deploy/install/Chart.yaml
@@ -28,6 +28,7 @@ dependencies:
   - name: drogue-cloud-metrics
     version: ^0.5.0-alpha1
     alias: drogueCloudMetrics
+    condition: drogueCloudMetrics.enabled, global.drogueCloudMetrics.enabled
     repository: file://../helm/charts/drogue-cloud-metrics
   - name: drogue-cloud-examples
     version: ^0.5.0-alpha1

--- a/deploy/install/Chart.yaml
+++ b/deploy/install/Chart.yaml
@@ -25,6 +25,10 @@ dependencies:
     version: ^0.5.0-alpha1
     alias: drogueCloudCore
     repository: file://../helm/charts/drogue-cloud-core
+  - name: drogue-cloud-metrics
+    version: ^0.5.0-alpha1
+    alias: drogueCloudMetrics
+    repository: file://../helm/charts/drogue-cloud-metrics
   - name: drogue-cloud-examples
     version: ^0.5.0-alpha1
     alias: drogueCloudExamples

--- a/deploy/install/values.yaml
+++ b/deploy/install/values.yaml
@@ -1,5 +1,9 @@
 drogueCloudMetrics:
   enabled: true
+  prometheus:
+    createInstance: true
+    kubeStateMetrics:
+      enabled: true
 
 drogueCloudTwin:
   enabled: false

--- a/deploy/install/values.yaml
+++ b/deploy/install/values.yaml
@@ -1,3 +1,6 @@
+drogueCloudMetrics:
+  enabled: true
+
 drogueCloudTwin:
   enabled: false
 

--- a/device-management-service/Cargo.toml
+++ b/device-management-service/Cargo.toml
@@ -14,6 +14,7 @@ async-trait = "0.1"
 actix-web = "=4.0.0-beta.19" # we need v4 as we need tokio 1
 actix-cors = "=0.6.0-beta.8"
 actix-web-httpauth = "=0.6.0-beta.7"
+prometheus = { version = "^0.13", default-features = false }
 
 http = "0.2"
 url = "2"

--- a/device-management-service/src/lib.rs
+++ b/device-management-service/src/lib.rs
@@ -233,7 +233,11 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     // run
 
     if let Some(health) = config.health {
-        let health = HealthServer::new(health, vec![Box::new(service)], None);
+        let health = HealthServer::new(
+            health,
+            vec![Box::new(service)],
+            Some(prometheus::default_registry().clone()),
+        );
         futures::try_join!(health.run(), main.err_into())?;
     } else {
         futures::try_join!(main)?;

--- a/device-management-service/src/lib.rs
+++ b/device-management-service/src/lib.rs
@@ -233,7 +233,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     // run
 
     if let Some(health) = config.health {
-        let health = HealthServer::new(health, vec![Box::new(service)]);
+        let health = HealthServer::new(health, vec![Box::new(service)], None);
         futures::try_join!(health.run(), main.err_into())?;
     } else {
         futures::try_join!(main)?;

--- a/docs/modules/deployment/nav.adoc
+++ b/docs/modules/deployment/nav.adoc
@@ -5,3 +5,4 @@
 ** xref:installer.adoc[Run the installer]
 ** xref:development.adoc[Deploy from the repository]
 ** xref:bare-metal.adoc[Deploying on bare metal]
+** xref:monitoring.adoc[Monitoring a deployment]

--- a/docs/modules/deployment/pages/installer.adoc
+++ b/docs/modules/deployment/pages/installer.adoc
@@ -72,6 +72,7 @@ The `deploy` command of `drgadm` supports the following argument
 `-n <namespace>` or `DROGUE_NS`:: Changes the target Drogue IoT namespace.
 `-T`:: Install digital twin feature.
 `-e`:: Don't install examples.
+`-M`:: Deploy metrics
 
 Example: Install Drogue Cloud on `kind` cluster without dependencies.
 

--- a/docs/modules/deployment/pages/monitoring.adoc
+++ b/docs/modules/deployment/pages/monitoring.adoc
@@ -1,0 +1,52 @@
+= Monitoring the deployment
+
+== Deploying
+
+Specifying `-M` during installation process will install Prometheus and Grafana allowing you to monitor your deployment.
+
+You can do that both using installer:
+
+[source,shell]
+----
+./script/drgadm deploy -M
+----
+
+Or during development:
+
+[source,bash]
+----
+env DEPLOY_ARGS="-M" make deploy
+----
+
+== Using
+
+You can find out the URL of the dashboard by running the `drgadm` script:
+
+[source,bash]
+----
+env METRICS=true scripts/drgadm examples
+----
+
+It should print something like:
+
+[source,bash]
+----
+View the metrics dashboard:
+----------------------------
+
+* Login to Grafana: https://metrics.192.168.64.131.nip.io
+* Default credentials are 'admin/admin123456' if not configured differently
+----
+
+== Configuring
+
+You can set values of the `drogue-cloud-metrics` Helm chart in order to configure various aspects of its deployment.
+
+For example, the following will
+
+[source,shell]
+----
+./script/drgadm deploy -M -s drogueCloudMetrics.grafana.adminPassword=654321nimda
+----
+
+will change the password for accessing Grafana dashboard.

--- a/endpoint-common/Cargo.toml
+++ b/endpoint-common/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 actix-web = "=4.0.0-beta.19" # we need v4 as we need tokio 1
 actix-broker = "0.4.0"
 actix-tls = { version = "^3.0.0", optional = true }
-prometheus = { version = "^0.12", default-features = false }
+prometheus = { version = "^0.13", default-features = false }
 lazy_static = "1.4.0"
 
 reqwest = { version = "0.11", features = ["json"] }

--- a/endpoint-common/Cargo.toml
+++ b/endpoint-common/Cargo.toml
@@ -10,6 +10,8 @@ license = "Apache-2.0"
 actix-web = "=4.0.0-beta.19" # we need v4 as we need tokio 1
 actix-broker = "0.4.0"
 actix-tls = { version = "^3.0.0", optional = true }
+prometheus = { version = "^0.12", default-features = false }
+lazy_static = "1.4.0"
 
 reqwest = { version = "0.11", features = ["json"] }
 

--- a/endpoint-common/src/sender/mod.rs
+++ b/endpoint-common/src/sender/mod.rs
@@ -13,10 +13,12 @@ use drogue_client::registry;
 use drogue_cloud_service_api::{EXT_INSTANCE, EXT_SENDER};
 use drogue_cloud_service_common::{Id, IdInjector};
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
+use process::Processor;
 use prometheus::{CounterVec, Opts};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
+use thiserror::Error;
 
 use lazy_static::lazy_static;
 

--- a/endpoint-common/src/sender/mod.rs
+++ b/endpoint-common/src/sender/mod.rs
@@ -19,6 +19,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 use thiserror::Error;
 use prometheus::{Encoder, CounterVec, Opts, Registry};
+use prometheus::{CounterVec, Opts};
 
 use lazy_static::lazy_static;
 

--- a/endpoint-common/src/sender/mod.rs
+++ b/endpoint-common/src/sender/mod.rs
@@ -18,6 +18,16 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 use thiserror::Error;
+use prometheus::{Encoder, CounterVec, Opts, Registry};
+
+use lazy_static::lazy_static;
+
+lazy_static! {
+    pub static ref DOWNSTREAM_EVENTS_COUNTER: CounterVec = CounterVec::new(
+        Opts::new("downstream_events", "Downstream events"),
+        &["endpoint", "outcome"]
+    ).unwrap();
+}
 
 const DEFAULT_TYPE_EVENT: &str = "io.drogue.event.v1";
 
@@ -91,6 +101,7 @@ where
     S: Sink,
 {
     pub fn new(sink: S, instance: String) -> anyhow::Result<Self> {
+        prometheus::default_registry().register(Box::new(DOWNSTREAM_EVENTS_COUNTER.clone())).unwrap();
         Ok(Self { sink, instance })
     }
 }
@@ -251,13 +262,26 @@ where
     where
         B: AsRef<[u8]> + Send + Sync,
     {
+
         match self.publish(publish, body).await {
-            Ok(PublishOutcome::Accepted) => HttpResponse::Accepted().finish(),
-            Ok(PublishOutcome::Rejected) => HttpResponse::NotAcceptable().finish(),
-            Ok(PublishOutcome::QueueFull) => HttpResponse::ServiceUnavailable().finish(),
-            Err(err) => HttpResponse::InternalServerError()
+            Ok(PublishOutcome::Accepted) => {
+                DOWNSTREAM_EVENTS_COUNTER.with_label_values(&["http", "Accepted"]).inc();
+                HttpResponse::Accepted().finish()
+            },
+            Ok(PublishOutcome::Rejected) => {
+                DOWNSTREAM_EVENTS_COUNTER.with_label_values(&["http", "Rejected"]).inc();
+                HttpResponse::NotAcceptable().finish()
+            },
+            Ok(PublishOutcome::QueueFull) => {
+                DOWNSTREAM_EVENTS_COUNTER.with_label_values(&["http", "QueueFull"]).inc();
+                HttpResponse::ServiceUnavailable().finish()
+            },
+            Err(err) => {
+                DOWNSTREAM_EVENTS_COUNTER.with_label_values(&["http", "Error"]).inc();
+                HttpResponse::InternalServerError()
                 .content_type("text/plain")
-                .body(err.to_string()),
+                .body(err.to_string())
+            },
         }
     }
 }

--- a/endpoint-common/src/sender/mod.rs
+++ b/endpoint-common/src/sender/mod.rs
@@ -25,7 +25,7 @@ use lazy_static::lazy_static;
 
 lazy_static! {
     pub static ref DOWNSTREAM_EVENTS_COUNTER: CounterVec = CounterVec::new(
-        Opts::new("downstream_events", "Downstream events"),
+        Opts::new("drogue_downstream_events", "Downstream events"),
         &["endpoint", "outcome"]
     ).unwrap();
 }

--- a/http-endpoint/Cargo.toml
+++ b/http-endpoint/Cargo.toml
@@ -15,6 +15,8 @@ async-trait = "0.1"
 actix-rt = "2"
 actix-tls = "^3.0.0"
 actix-web = "=4.0.0-beta.19" # we need v4 as we need tokio 1
+actix-web-prom = { git = "https://github.com/nlopes/actix-web-prom", rev = "41a3ff87a3f2bcf30a89474c149c119b30a02880" } #FIXME: use 0.6.0-beta.3 and upgrade actix-web
+prometheus = { version = "^0.12", default-features = false }
 
 futures = "0.3"
 futures-core = "0.3"

--- a/http-endpoint/Cargo.toml
+++ b/http-endpoint/Cargo.toml
@@ -15,7 +15,7 @@ async-trait = "0.1"
 actix-rt = "2"
 actix-tls = "^3.0.0"
 actix-web = "=4.0.0-beta.19" # we need v4 as we need tokio 1
-actix-web-prom = { git = "https://github.com/nlopes/actix-web-prom", branch="nlopes/bump-to-actix-web-14" } #FIXME: use 0.6.0-beta.3 and upgrade actix-web
+actix-web-prom = { git = "https://github.com/nlopes/actix-web-prom", branch="nlopes/bump-to-actix-web-14" } #FIXME: use 0.6.0-beta.4 when available
 prometheus = { version = "^0.13", default-features = false }
 
 futures = "0.3"

--- a/http-endpoint/Cargo.toml
+++ b/http-endpoint/Cargo.toml
@@ -15,8 +15,8 @@ async-trait = "0.1"
 actix-rt = "2"
 actix-tls = "^3.0.0"
 actix-web = "=4.0.0-beta.19" # we need v4 as we need tokio 1
-actix-web-prom = { git = "https://github.com/nlopes/actix-web-prom", rev = "41a3ff87a3f2bcf30a89474c149c119b30a02880" } #FIXME: use 0.6.0-beta.3 and upgrade actix-web
-prometheus = { version = "^0.12", default-features = false }
+actix-web-prom = { git = "https://github.com/nlopes/actix-web-prom", branch="nlopes/bump-to-actix-web-14" } #FIXME: use 0.6.0-beta.3 and upgrade actix-web
+prometheus = { version = "^0.13", default-features = false }
 
 futures = "0.3"
 futures-core = "0.3"

--- a/http-endpoint/src/downstream.rs
+++ b/http-endpoint/src/downstream.rs
@@ -48,30 +48,38 @@ where
         match self.publish(publish, body).await {
             // ok, and accepted
             Ok(PublishOutcome::Accepted) => {
-                DOWNSTREAM_EVENTS_COUNTER.with_label_values(&["http", "Accepted"]).inc();
+                DOWNSTREAM_EVENTS_COUNTER
+                    .with_label_values(&["http", "Accepted"])
+                    .inc();
                 wait_for_command(commands, filter, ttd).await
-            },
+            }
 
             // ok, but rejected
             Ok(PublishOutcome::Rejected) => {
-                DOWNSTREAM_EVENTS_COUNTER.with_label_values(&["http", "Rejected"]).inc();
+                DOWNSTREAM_EVENTS_COUNTER
+                    .with_label_values(&["http", "Rejected"])
+                    .inc();
                 Ok(HttpResponse::build(http::StatusCode::NOT_ACCEPTABLE).finish())
             }
 
             // ok, but rejected
             Ok(PublishOutcome::QueueFull) => {
-                DOWNSTREAM_EVENTS_COUNTER.with_label_values(&["http", "QueueFull"]).inc();
+                DOWNSTREAM_EVENTS_COUNTER
+                    .with_label_values(&["http", "QueueFull"])
+                    .inc();
                 Ok(HttpResponse::build(http::StatusCode::SERVICE_UNAVAILABLE).finish())
             }
 
             // internal error
             Err(err) => {
-                DOWNSTREAM_EVENTS_COUNTER.with_label_values(&["http", "Error"]).inc();
+                DOWNSTREAM_EVENTS_COUNTER
+                    .with_label_values(&["http", "Error"])
+                    .inc();
                 Ok(HttpResponse::InternalServerError().json(ErrorInformation {
-                error: "InternalError".into(),
-                message: err.to_string(),
-            }))
-            },
+                    error: "InternalError".into(),
+                    message: err.to_string(),
+                }))
+            }
         }
     }
 }

--- a/http-endpoint/src/lib.rs
+++ b/http-endpoint/src/lib.rs
@@ -23,7 +23,6 @@ use drogue_cloud_service_common::{
     health::{HealthServer, HealthServerConfig},
 };
 use futures::TryFutureExt;
-use prometheus::Registry;
 use serde::Deserialize;
 use serde_json::json;
 

--- a/http-endpoint/src/lib.rs
+++ b/http-endpoint/src/lib.rs
@@ -83,10 +83,9 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     let http_server_commands = commands.clone();
 
     let device_authenticator = DeviceAuthenticator::new(config.auth).await?;
-    let endpoint_registry = Registry::new();
 
     let prometheus = PrometheusMetricsBuilder::new("http_endpoint")
-        .registry(endpoint_registry.clone())
+        .registry(prometheus::default_registry().clone())
         .build()
         .unwrap();
 
@@ -181,7 +180,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
         let health = HealthServer::new(
             health,
             vec![Box::new(command_source)],
-            Some(endpoint_registry.clone()),
+            Some(prometheus::default_registry().clone()),
         );
         futures::try_join!(health.run(), http_server.err_into())?;
     } else {

--- a/installer/Makefile
+++ b/installer/Makefile
@@ -33,14 +33,15 @@ drogue-install-%-$(VERSION).zip: $(shell find $(TOPDIR)/../deploy -type f) $(she
 	rm $(OUTDIR)/stage/$(INSTALLER)/deploy/helm/.gitignore
 	rm $(OUTDIR)/stage/$(INSTALLER)/deploy/helm/README.md
 	# inject release version to the charts
-	sed -i 's/appVersion: .*$$/appVersion: "$(VERSION)"/' $(OUTDIR)/stage/$(INSTALLER)/deploy/helm/charts/drogue-cloud-common/Chart.yaml
-	sed -i 's/appVersion: .*$$/appVersion: "$(VERSION)"/' $(OUTDIR)/stage/$(INSTALLER)/deploy/helm/charts/drogue-cloud-core/Chart.yaml
-	sed -i 's/appVersion: .*$$/appVersion: "$(VERSION)"/' $(OUTDIR)/stage/$(INSTALLER)/deploy/helm/charts/drogue-cloud-examples/Chart.yaml
+	sed -i -e 's/appVersion: .*$$/appVersion: "$(VERSION)"/' $(OUTDIR)/stage/$(INSTALLER)/deploy/helm/charts/drogue-cloud-common/Chart.yaml
+	sed -i -e 's/appVersion: .*$$/appVersion: "$(VERSION)"/' $(OUTDIR)/stage/$(INSTALLER)/deploy/helm/charts/drogue-cloud-core/Chart.yaml
+	sed -i -e 's/appVersion: .*$$/appVersion: "$(VERSION)"/' $(OUTDIR)/stage/$(INSTALLER)/deploy/helm/charts/drogue-cloud-examples/Chart.yaml
+	sed -i -e 's/appVersion: .*$$/appVersion: "$(VERSION)"/' $(OUTDIR)/stage/$(INSTALLER)/deploy/helm/charts/drogue-cloud-metrics/Chart.yaml
 	# update the charts for the install wrapper
 	helm dep up $(OUTDIR)/stage/$(INSTALLER)/deploy/install
 	# inject release version to the scripts
-	sed -i 's/test-cert-generator:latest/test-cert-generator:$(VERSION)/g' $(OUTDIR)/stage/$(INSTALLER)/scripts/lib/common.sh
-	sed -i 's/CLUSTER:=minikube/CLUSTER:=$*/' $(OUTDIR)/stage/$(INSTALLER)/scripts/lib/common.sh
+	sed -i -e 's/test-cert-generator:latest/test-cert-generator:$(VERSION)/g' $(OUTDIR)/stage/$(INSTALLER)/scripts/lib/common.sh
+	sed -i -e 's/CLUSTER:=minikube/CLUSTER:=$*/' $(OUTDIR)/stage/$(INSTALLER)/scripts/lib/common.sh
 	cp README.md $(OUTDIR)/stage/$(INSTALLER)
 	# zip it up
 	@echo "::group::Create archives"

--- a/mqtt-endpoint/Cargo.toml
+++ b/mqtt-endpoint/Cargo.toml
@@ -16,7 +16,7 @@ ntex = "0.5"
 ntex-rt = "0.4"
 ntex-service = "0.3"
 ntex-mqtt = "0.8"
-prometheus = { version = "^0.12", default-features = false }
+prometheus = { version = "^0.13", default-features = false }
 
 bytes = "1"
 bytestring = "1"

--- a/mqtt-endpoint/Cargo.toml
+++ b/mqtt-endpoint/Cargo.toml
@@ -16,6 +16,7 @@ ntex = "0.5"
 ntex-rt = "0.4"
 ntex-service = "0.3"
 ntex-mqtt = "0.8"
+prometheus = { version = "^0.12", default-features = false }
 
 bytes = "1"
 bytestring = "1"

--- a/mqtt-endpoint/src/lib.rs
+++ b/mqtt-endpoint/src/lib.rs
@@ -48,6 +48,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
 
     // run
     if let Some(health) = config.health {
+        prometheus::default_registry().register(Box::new(MQTT_CONNECTIONS_COUNTER.clone())).unwrap();
         // health server
         let health = HealthServer::new(health, vec![Box::new(command_source)], Some(prometheus::default_registry().clone()),);
         futures::try_join!(health.run_ntex(), srv.err_into(),)?;

--- a/mqtt-endpoint/src/lib.rs
+++ b/mqtt-endpoint/src/lib.rs
@@ -48,9 +48,15 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
 
     // run
     if let Some(health) = config.health {
-        prometheus::default_registry().register(Box::new(MQTT_CONNECTIONS_COUNTER.clone())).unwrap();
+        prometheus::default_registry()
+            .register(Box::new(MQTT_CONNECTIONS_COUNTER.clone()))
+            .unwrap();
         // health server
-        let health = HealthServer::new(health, vec![Box::new(command_source)], Some(prometheus::default_registry().clone()),);
+        let health = HealthServer::new(
+            health,
+            vec![Box::new(command_source)],
+            Some(prometheus::default_registry().clone()),
+        );
         futures::try_join!(health.run_ntex(), srv.err_into(),)?;
     } else {
         futures::try_join!(srv)?;

--- a/mqtt-endpoint/src/lib.rs
+++ b/mqtt-endpoint/src/lib.rs
@@ -49,7 +49,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     // run
     if let Some(health) = config.health {
         // health server
-        let health = HealthServer::new(health, vec![Box::new(command_source)]);
+        let health = HealthServer::new(health, vec![Box::new(command_source)], None);
         futures::try_join!(health.run_ntex(), srv.err_into(),)?;
     } else {
         futures::try_join!(srv)?;

--- a/mqtt-endpoint/src/lib.rs
+++ b/mqtt-endpoint/src/lib.rs
@@ -49,7 +49,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     // run
     if let Some(health) = config.health {
         // health server
-        let health = HealthServer::new(health, vec![Box::new(command_source)], None);
+        let health = HealthServer::new(health, vec![Box::new(command_source)], Some(prometheus::default_registry().clone()),);
         futures::try_join!(health.run_ntex(), srv.err_into(),)?;
     } else {
         futures::try_join!(srv)?;

--- a/mqtt-endpoint/src/lib.rs
+++ b/mqtt-endpoint/src/lib.rs
@@ -13,6 +13,13 @@ use drogue_cloud_endpoint_common::{
 use drogue_cloud_mqtt_common::server::build;
 use drogue_cloud_service_common::health::HealthServer;
 use futures::TryFutureExt;
+use lazy_static::lazy_static;
+use prometheus::IntGauge;
+
+lazy_static! {
+    pub static ref MQTT_CONNECTIONS_COUNTER: IntGauge =
+        IntGauge::new("drogue_mqtt_connections", "Mqtt Connections").unwrap();
+}
 
 pub async fn run(config: Config) -> anyhow::Result<()> {
     let commands = Commands::new();

--- a/mqtt-endpoint/src/service/session/mod.rs
+++ b/mqtt-endpoint/src/service/session/mod.rs
@@ -23,6 +23,7 @@ use std::{
     collections::{hash_map::Entry, HashMap},
     sync::Arc,
 };
+use crate::MQTT_CONNECTIONS_COUNTER;
 
 #[derive(Clone)]
 pub struct Session<S>
@@ -58,6 +59,7 @@ where
             device.metadata.name.clone(),
         );
         let device_cache = cache::DeviceCache::new(config.cache_size, config.cache_duration);
+        MQTT_CONNECTIONS_COUNTER.inc();
         Self {
             auth,
             sender,
@@ -272,6 +274,7 @@ where
         for (_, v) in self.inbox_reader.lock().await.drain() {
             v.close().await;
         }
+        MQTT_CONNECTIONS_COUNTER.dec();
         Ok(())
     }
 }

--- a/mqtt-endpoint/src/service/session/mod.rs
+++ b/mqtt-endpoint/src/service/session/mod.rs
@@ -1,8 +1,8 @@
 mod cache;
 mod inbox;
 
-use crate::{auth::DeviceAuthenticator, config::EndpointConfig};
 use crate::MQTT_CONNECTIONS_COUNTER;
+use crate::{auth::DeviceAuthenticator, config::EndpointConfig};
 use async_trait::async_trait;
 use cache::DeviceCache;
 use drogue_client::registry;

--- a/mqtt-endpoint/src/service/session/mod.rs
+++ b/mqtt-endpoint/src/service/session/mod.rs
@@ -2,12 +2,16 @@ mod cache;
 mod inbox;
 
 use crate::{auth::DeviceAuthenticator, config::EndpointConfig};
+use crate::MQTT_CONNECTIONS_COUNTER;
 use async_trait::async_trait;
 use cache::DeviceCache;
 use drogue_client::registry;
 use drogue_cloud_endpoint_common::{
     command::{CommandFilter, Commands},
-    sender::{self, DownstreamSender, PublishOptions, PublishOutcome, Publisher, DOWNSTREAM_EVENTS_COUNTER},
+    sender::{
+        self, DownstreamSender, PublishOptions, PublishOutcome, Publisher,
+        DOWNSTREAM_EVENTS_COUNTER,
+    },
     sink::Sink,
 };
 use drogue_cloud_mqtt_common::{
@@ -23,7 +27,6 @@ use std::{
     collections::{hash_map::Entry, HashMap},
     sync::Arc,
 };
-use crate::MQTT_CONNECTIONS_COUNTER;
 
 #[derive(Clone)]
 pub struct Session<S>
@@ -171,21 +174,29 @@ where
             .await
         {
             Ok(PublishOutcome::Accepted) => {
-                DOWNSTREAM_EVENTS_COUNTER.with_label_values(&["mqtt", "Accepted"]).inc();
+                DOWNSTREAM_EVENTS_COUNTER
+                    .with_label_values(&["mqtt", "Accepted"])
+                    .inc();
                 Ok(())
-            },
+            }
             Ok(PublishOutcome::Rejected) => {
-                DOWNSTREAM_EVENTS_COUNTER.with_label_values(&["mqtt", "Rejected"]).inc();
+                DOWNSTREAM_EVENTS_COUNTER
+                    .with_label_values(&["mqtt", "Rejected"])
+                    .inc();
                 Err(PublishError::UnspecifiedError)
-            },
+            }
             Ok(PublishOutcome::QueueFull) => {
-                DOWNSTREAM_EVENTS_COUNTER.with_label_values(&["mqtt", "QueueFull"]).inc();
+                DOWNSTREAM_EVENTS_COUNTER
+                    .with_label_values(&["mqtt", "QueueFull"])
+                    .inc();
                 Err(PublishError::QuotaExceeded)
-            },
+            }
             Err(err) => {
-                DOWNSTREAM_EVENTS_COUNTER.with_label_values(&["mqtt", "Error"]).inc();
+                DOWNSTREAM_EVENTS_COUNTER
+                    .with_label_values(&["mqtt", "Error"])
+                    .inc();
                 Err(PublishError::InternalError(err.to_string()))
-            },
+            }
         }
     }
 

--- a/mqtt-integration/Cargo.toml
+++ b/mqtt-integration/Cargo.toml
@@ -16,6 +16,7 @@ ntex-rt = "0.4"
 ntex-service = "0.3"
 ntex-mqtt = "0.8"
 ntex-bytes = "0.1"
+prometheus = { version = "^0.13", default-features = false }
 
 bytes = "1"
 bytestring = "1"

--- a/mqtt-integration/src/lib.rs
+++ b/mqtt-integration/src/lib.rs
@@ -139,7 +139,8 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
 
     if let Some(health) = config.health {
         // health server
-        let health = HealthServer::new(health, vec![], None);
+        let health =
+            HealthServer::new(health, vec![], Some(prometheus::default_registry().clone()));
         futures::try_join!(health.run_ntex(), srv.err_into(),)?;
     } else {
         futures::try_join!(srv)?;

--- a/mqtt-integration/src/lib.rs
+++ b/mqtt-integration/src/lib.rs
@@ -139,7 +139,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
 
     if let Some(health) = config.health {
         // health server
-        let health = HealthServer::new(health, vec![]);
+        let health = HealthServer::new(health, vec![], None);
         futures::try_join!(health.run_ntex(), srv.err_into(),)?;
     } else {
         futures::try_join!(srv)?;

--- a/outbox-controller/Cargo.toml
+++ b/outbox-controller/Cargo.toml
@@ -26,6 +26,7 @@ serde_json = "1"
 indexmap = { version = "1", features = ["serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 reqwest = "0.11"
+prometheus = { version = "^0.13", default-features = false }
 
 deadpool = "0.7"
 deadpool-postgres = { version = "0.7", features = ["config"] }

--- a/outbox-controller/src/lib.rs
+++ b/outbox-controller/src/lib.rs
@@ -91,7 +91,8 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     // run
 
     if let Some(health) = config.health {
-        let health = HealthServer::new(health, vec![], None);
+        let health =
+            HealthServer::new(health, vec![], Some(prometheus::default_registry().clone()));
         futures::try_join!(health.run(), source.err_into())?;
     } else {
         futures::try_join!(source)?;

--- a/outbox-controller/src/lib.rs
+++ b/outbox-controller/src/lib.rs
@@ -91,7 +91,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     // run
 
     if let Some(health) = config.health {
-        let health = HealthServer::new(health, vec![]);
+        let health = HealthServer::new(health, vec![], None);
         futures::try_join!(health.run(), source.err_into())?;
     } else {
         futures::try_join!(source)?;

--- a/scripts/cmd/__endpoints.sh
+++ b/scripts/cmd/__endpoints.sh
@@ -24,7 +24,8 @@ WEBSOCKET_INTEGRATION_HOST="$(echo "$WEBSOCKET_INTEGRATION_URL" | sed -E -e 's/:
 HTTP_ENDPOINT_URL="$(get_env deploy/console-backend endpoint ENDPOINTS__HTTP_ENDPOINT_URL)"
 HTTP_ENDPOINT_HOST="$(echo "$HTTP_ENDPOINT_URL" | sed -E -e 's/:[0-9]+$//' -e 's|^https?://||' )"
 
-DASHBOARD_URL="grafana$(detect_domain)"
+EXAMPLES_DASHBOARD_URL="grafana$(detect_domain)"
+METRICS_DASHBOARD_URL="metrics$(detect_domain)"
 
 if [[ -z "$SILENT" ]]; then
 

--- a/scripts/cmd/deploy.sh
+++ b/scripts/cmd/deploy.sh
@@ -198,6 +198,7 @@ HELM_ARGS="$HELM_ARGS --set global.domain=${domain}"
 HELM_ARGS="$HELM_ARGS --set coreReleaseName=drogue-iot"
 HELM_ARGS="$HELM_ARGS --set drogueCloudTwin.enabled=$DEPLOY_TWIN"
 HELM_ARGS="$HELM_ARGS --set drogueCloudExamples.enabled=$DEPLOY_EXAMPLES"
+HELM_ARGS="$HELM_ARGS --set drogueCloudMetrics.grafana.ingress.hosts={metrics${domain}}"
 
 echo "Helm arguments: $HELM_ARGS"
 

--- a/scripts/cmd/deploy.sh
+++ b/scripts/cmd/deploy.sh
@@ -199,6 +199,7 @@ HELM_ARGS="$HELM_ARGS --set coreReleaseName=drogue-iot"
 HELM_ARGS="$HELM_ARGS --set drogueCloudTwin.enabled=$DEPLOY_TWIN"
 HELM_ARGS="$HELM_ARGS --set drogueCloudExamples.enabled=$DEPLOY_EXAMPLES"
 HELM_ARGS="$HELM_ARGS --set drogueCloudMetrics.grafana.ingress.hosts={metrics${domain}}"
+HELM_ARGS="$HELM_ARGS --set drogueCloudMetrics.prometheus.server.ingress.hosts={prometheus${domain}}"
 
 echo "Helm arguments: $HELM_ARGS"
 

--- a/scripts/cmd/deploy.sh
+++ b/scripts/cmd/deploy.sh
@@ -44,7 +44,7 @@ EOF
     exit 1
 }
 
-while getopts mhkep:c:n:d:s:S:t:Tf: FLAG; do
+while getopts mhkeMp:c:n:d:s:S:t:Tf: FLAG; do
   case $FLAG in
     c)
         CLUSTER="$OPTARG"
@@ -203,6 +203,7 @@ HELM_ARGS="$HELM_ARGS --set global.domain=${domain}"
 HELM_ARGS="$HELM_ARGS --set coreReleaseName=drogue-iot"
 HELM_ARGS="$HELM_ARGS --set drogueCloudTwin.enabled=$DEPLOY_TWIN"
 HELM_ARGS="$HELM_ARGS --set drogueCloudExamples.enabled=$DEPLOY_EXAMPLES"
+HELM_ARGS="$HELM_ARGS --set drogueCloudMetrics.enabled=$DEPLOY_METRICS"
 HELM_ARGS="$HELM_ARGS --set drogueCloudMetrics.grafana.ingress.hosts={metrics${domain}}"
 
 echo "Helm arguments: $HELM_ARGS"
@@ -211,6 +212,7 @@ echo "Helm arguments: $HELM_ARGS"
 
 progress -n "🔨 Deploying Drogue IoT ... "
 helm dependency update "$BASEDIR/../deploy/install"
+helm dependency update "$BASEDIR/../deploy/helm/charts/drogue-cloud-metrics"
 # shellcheck disable=SC2086
 helm -n "$DROGUE_NS" upgrade drogue-iot "$BASEDIR/../deploy/install" --install $HELM_ARGS
 progress "done!"

--- a/scripts/cmd/deploy.sh
+++ b/scripts/cmd/deploy.sh
@@ -6,6 +6,7 @@ set +e
 
 : "${DEPLOY_TWIN:=false}"
 : "${DEPLOY_EXAMPLES:=true}"
+: "${DEPLOY_METRICS:=FALSE}"
 
 # process arguments
 
@@ -30,6 +31,7 @@ Options:
   -p <profile>       Enable Helm profile (adds 'deploy/profiles/<profile>.yaml')
   -t <timeout>       Helm installation timeout (default: 15m)
   -T                 Deploy the digital twin feature
+  -M                 Deploy metrics
   -h                 Show this help
 
 EOF
@@ -76,6 +78,9 @@ while getopts mhkep:c:n:d:s:S:t:Tf: FLAG; do
         ;;
     T)
         DEPLOY_TWIN="true"
+        ;;
+    M)
+        DEPLOY_METRICS="true"
         ;;
     e)
         DEPLOY_EXAMPLES="false"
@@ -199,7 +204,6 @@ HELM_ARGS="$HELM_ARGS --set coreReleaseName=drogue-iot"
 HELM_ARGS="$HELM_ARGS --set drogueCloudTwin.enabled=$DEPLOY_TWIN"
 HELM_ARGS="$HELM_ARGS --set drogueCloudExamples.enabled=$DEPLOY_EXAMPLES"
 HELM_ARGS="$HELM_ARGS --set drogueCloudMetrics.grafana.ingress.hosts={metrics${domain}}"
-HELM_ARGS="$HELM_ARGS --set drogueCloudMetrics.prometheus.server.ingress.hosts={prometheus${domain}}"
 
 echo "Helm arguments: $HELM_ARGS"
 

--- a/scripts/cmd/deploy.sh
+++ b/scripts/cmd/deploy.sh
@@ -6,7 +6,7 @@ set +e
 
 : "${DEPLOY_TWIN:=false}"
 : "${DEPLOY_EXAMPLES:=true}"
-: "${DEPLOY_METRICS:=FALSE}"
+: "${DEPLOY_METRICS:=false}"
 
 # process arguments
 
@@ -291,7 +291,11 @@ if [[ "$DEPLOY_TWIN" == true ]]; then
 fi
 
 if [[ "$DEPLOY_EXAMPLES" == false ]]; then
-    ENVS+="EXAMPLES=false"
+    ENVS+="EXAMPLES=false "
+fi
+
+if [[ "$DEPLOY_METRICS" == true ]]; then
+    ENVS+="METRICS=true "
 fi
 
 if ! is_default_cluster; then

--- a/scripts/cmd/examples.sh
+++ b/scripts/cmd/examples.sh
@@ -26,6 +26,17 @@ echo "  Password: admin123456"
 echo
 echo "$(bold -n Console:) $CONSOLE_URL"
 echo
+
+if [[ "$METRICS" == "true" ]]; then
+echo
+bold "View the metrics dashboard:"
+bold "----------------------------"
+echo
+echo "* Login to Grafana: https://$METRICS_DASHBOARD_URL"
+echo "* Default credentials are 'admin/admin123456' if not configured differently"
+echo
+fi
+
 bold "------------------------------------------------------------------------------------------"
 bold "Examples"
 bold "------------------------------------------------------------------------------------------"
@@ -35,7 +46,7 @@ echo
 bold "View the example dashboard (if it's installed):"
 bold "----------------------------"
 echo
-echo "* Login to Grafana (using SSO): $DASHBOARD_URL"
+echo "* Login to Grafana (using SSO): https://$EXAMPLES_DASHBOARD_URL"
 echo "* You will be presented with the 'Temperatures dashboard'"
 fi
 

--- a/service-common/Cargo.toml
+++ b/service-common/Cargo.toml
@@ -18,7 +18,7 @@ actix-service = "2"
 actix-rt = "2"
 ntex = { version = "0.5", features = ["tokio"] }
 http = "0.2"
-actix-web-prom = { git = "https://github.com/nlopes/actix-web-prom", branch="nlopes/bump-to-actix-web-14" } #FIXME: use 0.6.0-beta.3 and upgrade actix-web
+actix-web-prom = { git = "https://github.com/nlopes/actix-web-prom", branch="nlopes/bump-to-actix-web-14" } #FIXME: use 0.6.0-beta.4 when available
 prometheus = { version = "^0.13", default-features = false }
 
 keycloak = "14"

--- a/service-common/Cargo.toml
+++ b/service-common/Cargo.toml
@@ -18,8 +18,8 @@ actix-service = "2"
 actix-rt = "2"
 ntex = { version = "0.5", features = ["tokio"] }
 http = "0.2"
-actix-web-prom = { git = "https://github.com/nlopes/actix-web-prom", rev = "41a3ff87a3f2bcf30a89474c149c119b30a02880" } #FIXME: use 0.6.0-beta.3 and upgrade actix-web
-prometheus = { version = "^0.12", default-features = false }
+actix-web-prom = { git = "https://github.com/nlopes/actix-web-prom", branch="nlopes/bump-to-actix-web-14" } #FIXME: use 0.6.0-beta.3 and upgrade actix-web
+prometheus = { version = "^0.13", default-features = false }
 
 keycloak = "14"
 

--- a/service-common/Cargo.toml
+++ b/service-common/Cargo.toml
@@ -18,6 +18,8 @@ actix-service = "2"
 actix-rt = "2"
 ntex = { version = "0.5", features = ["tokio"] }
 http = "0.2"
+actix-web-prom = { git = "https://github.com/nlopes/actix-web-prom", rev = "41a3ff87a3f2bcf30a89474c149c119b30a02880" } #FIXME: use 0.6.0-beta.3 and upgrade actix-web
+prometheus = { version = "^0.12", default-features = false }
 
 keycloak = "14"
 

--- a/service-common/src/health.rs
+++ b/service-common/src/health.rs
@@ -161,8 +161,7 @@ impl HealthServer {
         let checker = ntex::web::types::Data::new(self.checker);
         ntex::web::server(move || {
             use ntex::web::App;
-            health_app!(checker)
-            .route("/metrics", web::get().to(HealthServer::metrics))
+            health_app!(checker).route("/metrics", web::get().to(HealthServer::metrics))
         })
         .bind(self.config.bind_addr)?
         .workers(self.config.workers)
@@ -179,7 +178,8 @@ impl HealthServer {
             .encode(&prometheus::gather(), &mut buffer)
             .expect("Failed to encode metrics");
 
-        let response = String::from_utf8(buffer.clone()).expect("Failed to convert bytes to string");
+        let response =
+            String::from_utf8(buffer.clone()).expect("Failed to convert bytes to string");
         buffer.clear();
 
         ntex::web::HttpResponse::Ok()

--- a/topic-admin-operator/Cargo.toml
+++ b/topic-admin-operator/Cargo.toml
@@ -27,6 +27,7 @@ url = "2"
 serde = "1"
 serde_json = "1"
 reqwest = "0.11"
+prometheus = { version = "^0.13", default-features = false }
 
 drogue-cloud-database-common = { path = "../database-common" }
 drogue-cloud-service-common = { path = "../service-common" }

--- a/topic-admin-operator/src/lib.rs
+++ b/topic-admin-operator/src/lib.rs
@@ -88,7 +88,8 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
 
     log::info!("Running service ...");
     if let Some(health) = config.health {
-        let health = HealthServer::new(health, vec![], None);
+        let health =
+            HealthServer::new(health, vec![], Some(prometheus::default_registry().clone()));
         select! {
             _ = health.run().fuse() => (),
             _ = registry.fuse() => (),

--- a/topic-admin-operator/src/lib.rs
+++ b/topic-admin-operator/src/lib.rs
@@ -88,7 +88,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
 
     log::info!("Running service ...");
     if let Some(health) = config.health {
-        let health = HealthServer::new(health, vec![]);
+        let health = HealthServer::new(health, vec![], None);
         select! {
             _ = health.run().fuse() => (),
             _ = registry.fuse() => (),

--- a/topic-strimzi-operator/Cargo.toml
+++ b/topic-strimzi-operator/Cargo.toml
@@ -27,6 +27,7 @@ url = "2"
 serde = "1"
 serde_json = "1"
 reqwest = "0.11"
+prometheus = { version = "^0.13", default-features = false }
 
 kube = "0.58"
 kube-derive = "0.58"

--- a/topic-strimzi-operator/src/lib.rs
+++ b/topic-strimzi-operator/src/lib.rs
@@ -150,7 +150,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
 
     log::info!("Running service ...");
     if let Some(health) = config.health {
-        let health = HealthServer::new(health, vec![]);
+        let health = HealthServer::new(health, vec![], None);
         futures::try_join!(
             health.run(),
             registry,

--- a/topic-strimzi-operator/src/lib.rs
+++ b/topic-strimzi-operator/src/lib.rs
@@ -150,7 +150,8 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
 
     log::info!("Running service ...");
     if let Some(health) = config.health {
-        let health = HealthServer::new(health, vec![], None);
+        let health =
+            HealthServer::new(health, vec![], Some(prometheus::default_registry().clone()));
         futures::try_join!(
             health.run(),
             registry,

--- a/ttn-operator/Cargo.toml
+++ b/ttn-operator/Cargo.toml
@@ -37,6 +37,7 @@ serde = "1"
 serde_json = "1"
 url = "2"
 x509-parser = "0.9"
+prometheus = { version = "^0.13", default-features = false }
 
 drogue-cloud-database-common = { path = "../database-common" }
 drogue-cloud-service-common = { path = "../service-common" }

--- a/ttn-operator/src/lib.rs
+++ b/ttn-operator/src/lib.rs
@@ -119,7 +119,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
 
     log::info!("Running service ...");
     if let Some(health) = config.health {
-        let health = HealthServer::new(health, vec![]);
+        let health = HealthServer::new(health, vec![], None);
         futures::try_join!(health.run(), source.err_into())?;
     } else {
         futures::try_join!(source)?;

--- a/ttn-operator/src/lib.rs
+++ b/ttn-operator/src/lib.rs
@@ -119,7 +119,8 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
 
     log::info!("Running service ...");
     if let Some(health) = config.health {
-        let health = HealthServer::new(health, vec![], None);
+        let health =
+            HealthServer::new(health, vec![], Some(prometheus::default_registry().clone()));
         futures::try_join!(health.run(), source.err_into())?;
     } else {
         futures::try_join!(source)?;

--- a/user-auth-service/Cargo.toml
+++ b/user-auth-service/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1"
 
 actix-web = "=4.0.0-beta.19" # we need v4 as we need tokio 1
 actix-web-httpauth = "=0.6.0-beta.7"
+prometheus = { version = "^0.13", default-features = false }
 
 tokio = { version = "1", features = ["full"] }
 

--- a/user-auth-service/src/lib.rs
+++ b/user-auth-service/src/lib.rs
@@ -115,7 +115,7 @@ where
     };
 
     if let Some(health) = config.health {
-        let health = HealthServer::new(health, vec![Box::new(data_service)]);
+        let health = HealthServer::new(health, vec![Box::new(data_service)], None);
         futures::try_join!(health.run(), main.err_into())?;
     } else {
         futures::try_join!(main)?;

--- a/user-auth-service/src/lib.rs
+++ b/user-auth-service/src/lib.rs
@@ -115,7 +115,11 @@ where
     };
 
     if let Some(health) = config.health {
-        let health = HealthServer::new(health, vec![Box::new(data_service)], None);
+        let health = HealthServer::new(
+            health,
+            vec![Box::new(data_service)],
+            Some(prometheus::default_registry().clone()),
+        );
         futures::try_join!(health.run(), main.err_into())?;
     } else {
         futures::try_join!(main)?;

--- a/websocket-integration/Cargo.toml
+++ b/websocket-integration/Cargo.toml
@@ -14,6 +14,7 @@ actix-http = "=3.0.0-beta.18"
 actix-web = "=4.0.0-beta.19"
 actix-web-actors = "=4.0.0-beta.10"
 actix-web-httpauth = "=0.6.0-beta.7"
+prometheus = { version = "^0.13", default-features = false }
 
 dotenv = "0.15"
 

--- a/websocket-integration/src/lib.rs
+++ b/websocket-integration/src/lib.rs
@@ -105,7 +105,8 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
 
     // run
     if let Some(health) = config.health {
-        let health = HealthServer::new(health, vec![], None);
+        let health =
+            HealthServer::new(health, vec![], Some(prometheus::default_registry().clone()));
         futures::try_join!(health.run(), main.err_into())?;
     } else {
         futures::try_join!(main)?;

--- a/websocket-integration/src/lib.rs
+++ b/websocket-integration/src/lib.rs
@@ -105,7 +105,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
 
     // run
     if let Some(health) = config.health {
-        let health = HealthServer::new(health, vec![]);
+        let health = HealthServer::new(health, vec![], None);
         futures::try_join!(health.run(), main.err_into())?;
     } else {
         futures::try_join!(main)?;


### PR DESCRIPTION
Add metrics for cloud components based on Prometheus/Grafana.
It works in combination with https://github.com/drogue-iot/drogue-cloud-helm-charts/pull/12

This PR adds basics for drogue cloud monitoring, by:

- adding drogue-cloud-metrics chart and option to install it
- instrumenting for now http and mqtt endpoint with basic metrics

There's a new docs page with some explanations:
[docs/modules/deployment/pages/monitoring.adoc](https://github.com/drogue-iot/drogue-cloud/blob/1afa2185ee43c4b17d500468943211a3a70e50b9/docs/modules/deployment/pages/monitoring.adoc)
which should help with testing the PR.
Short term TODO item is to bump `actix-web-prom` version once the https://github.com/nlopes/actix-web-prom/pull/61 is merged.