### PR TITLE
Limit `actix-web` dep to `service-api` only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1717,10 +1717,8 @@ dependencies = [
 name = "drogue-cloud-access-token-service"
 version = "0.9.0"
 dependencies = [
- "actix-http 3.0.0-beta.18",
  "actix-rt 2.6.0",
  "actix-service 2.0.0",
- "actix-web",
  "anyhow",
  "async-trait",
  "base62",
@@ -1758,8 +1756,6 @@ dependencies = [
 name = "drogue-cloud-admin-service"
 version = "0.9.0"
 dependencies = [
- "actix-http 3.0.0-beta.18",
- "actix-web",
  "anyhow",
  "async-trait",
  "chrono",
@@ -1788,8 +1784,6 @@ version = "0.9.0"
 dependencies = [
  "actix-rt 2.6.0",
  "actix-service 2.0.0",
- "actix-web",
- "actix-web-httpauth",
  "anyhow",
  "async-trait",
  "bcrypt",
@@ -1832,7 +1826,6 @@ name = "drogue-cloud-coap-endpoint"
 version = "0.9.0"
 dependencies = [
  "actix-rt 2.6.0",
- "actix-web",
  "anyhow",
  "async-trait",
  "bytes 1.1.0",
@@ -1864,8 +1857,6 @@ name = "drogue-cloud-command-endpoint"
 version = "0.9.0"
 dependencies = [
  "actix-cors",
- "actix-web",
- "actix-web-httpauth",
  "anyhow",
  "async-trait",
  "base64 0.13.0",
@@ -1896,10 +1887,7 @@ dependencies = [
 name = "drogue-cloud-console-backend"
 version = "0.9.0"
 dependencies = [
- "actix",
  "actix-cors",
- "actix-web",
- "actix-web-httpauth",
  "anyhow",
  "async-trait",
  "awc 3.0.0-beta.18",
@@ -1949,7 +1937,6 @@ dependencies = [
 name = "drogue-cloud-database-common"
 version = "0.9.0"
 dependencies = [
- "actix-web",
  "anyhow",
  "async-trait",
  "chrono",
@@ -1980,8 +1967,6 @@ dependencies = [
  "actix-cors",
  "actix-http 3.0.0-beta.18",
  "actix-rt 2.6.0",
- "actix-web",
- "actix-web-httpauth",
  "anyhow",
  "async-trait",
  "base64 0.13.0",
@@ -2032,7 +2017,6 @@ version = "0.9.0"
 dependencies = [
  "actix-broker",
  "actix-tls",
- "actix-web",
  "anyhow",
  "async-std",
  "async-trait",
@@ -2096,7 +2080,6 @@ version = "0.9.0"
 dependencies = [
  "actix-rt 2.6.0",
  "actix-tls",
- "actix-web",
  "actix-web-prom",
  "anyhow",
  "async-trait",
@@ -2133,7 +2116,6 @@ dependencies = [
 name = "drogue-cloud-integration-common"
 version = "0.9.0"
 dependencies = [
- "actix-web",
  "async-trait",
  "base64 0.13.0",
  "bytes 1.1.0",
@@ -2152,6 +2134,13 @@ dependencies = [
  "thiserror",
  "tokio-stream",
  "url",
+]
+
+[[package]]
+name = "drogue-cloud-macros"
+version = "0.1.0"
+dependencies = [
+ "quote",
 ]
 
 [[package]]
@@ -2390,14 +2379,17 @@ dependencies = [
 name = "drogue-cloud-service-api"
 version = "0.9.0"
 dependencies = [
+ "actix-http 3.0.0-beta.18",
+ "actix-rt 2.6.0",
  "actix-web",
+ "actix-web-httpauth",
  "async-trait",
  "base64 0.13.0",
  "base64-serde",
  "chrono",
  "config 0.11.0",
  "drogue-client",
- "futures",
+ "drogue-cloud-macros",
  "indexmap",
  "lazy_static 1.4.0",
  "log",
@@ -2416,11 +2408,7 @@ name = "drogue-cloud-service-common"
 version = "0.9.0"
 dependencies = [
  "actix",
- "actix-http 3.0.0-beta.18",
- "actix-rt 2.6.0",
  "actix-service 2.0.0",
- "actix-web",
- "actix-web-httpauth",
  "actix-web-prom",
  "anyhow",
  "async-std",
@@ -2582,8 +2570,6 @@ version = "0.9.0"
 dependencies = [
  "actix-rt 2.6.0",
  "actix-service 2.0.0",
- "actix-web",
- "actix-web-httpauth",
  "anyhow",
  "async-trait",
  "chrono",
@@ -2621,10 +2607,7 @@ name = "drogue-cloud-websocket-integration"
 version = "0.9.0"
 dependencies = [
  "actix",
- "actix-http 3.0.0-beta.18",
- "actix-web",
  "actix-web-actors",
- "actix-web-httpauth",
  "anyhow",
  "awc 2.0.3",
  "bytes 0.5.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "device-management-service",
     "database-common",
     "service-common",
+    "macros",
     "service-api",
     "command-endpoint",
     "test-common",

--- a/access-token-service/Cargo.toml
+++ b/access-token-service/Cargo.toml
@@ -11,9 +11,6 @@ license = "Apache-2.0"
 
 anyhow = "1"
 
-actix-http = "=3.0.0-beta.18" # FIXME: temporary intermediate
-actix-web = "=4.0.0-beta.19" # we need v4 as we need tokio 1
-
 tokio = { version = "1", features = ["full"] }
 
 async-trait = "0.1"

--- a/access-token-service/src/endpoints.rs
+++ b/access-token-service/src/endpoints.rs
@@ -1,5 +1,6 @@
 use crate::service::AccessTokenService;
 use actix_web::{web, HttpResponse};
+use drogue_cloud_service_api::webapp as actix_web;
 use drogue_cloud_service_api::{
     auth::user::{
         authn::{AuthenticationRequest, AuthenticationResponse, Outcome},

--- a/access-token-service/src/mock.rs
+++ b/access-token-service/src/mock.rs
@@ -1,6 +1,6 @@
 use crate::service::AccessTokenService;
-use actix_web::ResponseError;
 use async_trait::async_trait;
+use drogue_cloud_service_api::webapp::ResponseError;
 use drogue_cloud_service_api::{
     auth::user::{UserDetails, UserInformation},
     token::{AccessToken, AccessTokenCreated, AccessTokenCreationOptions},

--- a/access-token-service/src/service.rs
+++ b/access-token-service/src/service.rs
@@ -1,6 +1,6 @@
-use actix_web::ResponseError;
 use async_trait::async_trait;
 use chrono::Utc;
+use drogue_cloud_service_api::webapp::ResponseError;
 use drogue_cloud_service_api::{
     auth::user::{UserDetails, UserInformation},
     token::{AccessToken, AccessTokenCreated, AccessTokenCreationOptions, AccessTokenData},

--- a/admin-service/Cargo.toml
+++ b/admin-service/Cargo.toml
@@ -11,12 +11,9 @@ license = "Apache-2.0"
 
 anyhow = "1"
 
-actix-http = { version = "=3.0.0-beta.18", optional = true } # FIXME: temporary intermediate
-actix-web = { version = "=4.0.0-beta.19", optional = true } # we need v4 as we need tokio 1
-
 tokio = { version = "1", features = ["full"] }
 
-async-trait = { version = "0.1", optional = true }
+async-trait = "0.1"
 futures = "0.3"
 futures-core = "0.3"
 futures-util = "0.3"
@@ -40,8 +37,3 @@ drogue-cloud-endpoint-common = { path = "../endpoint-common" }
 drogue-cloud-service-api = { path = "../service-api" }
 drogue-cloud-service-common = { path = "../service-common", features = ["rustls"] }
 drogue-cloud-registry-events = { path = "../registry-events" }
-
-[features]
-default = ["service", "endpoints"]
-service = ["async-trait"]
-endpoints = ["actix-http", "actix-web"]

--- a/admin-service/src/apps/endpoints.rs
+++ b/admin-service/src/apps/endpoints.rs
@@ -1,5 +1,6 @@
 use crate::apps::service::AdminService;
 use actix_web::{web, HttpResponse};
+use drogue_cloud_service_api::webapp as actix_web;
 use drogue_cloud_service_api::{
     admin::{Members, TransferOwnership},
     auth::user::UserInformation,

--- a/admin-service/src/apps/service.rs
+++ b/admin-service/src/apps/service.rs
@@ -1,7 +1,7 @@
-use actix_web::ResponseError;
 use async_trait::async_trait;
 use drogue_cloud_service_api::admin::{Members, TransferOwnership};
 use drogue_cloud_service_api::auth::user::UserInformation;
+use drogue_cloud_service_api::webapp::ResponseError;
 
 #[async_trait]
 pub trait AdminService: Clone {

--- a/authentication-service/Cargo.toml
+++ b/authentication-service/Cargo.toml
@@ -12,8 +12,6 @@ license = "Apache-2.0"
 
 anyhow = "1"
 
-actix-web = "=4.0.0-beta.19" # we need v4 as we need tokio 1
-actix-web-httpauth = "=0.6.0-beta.7"
 prometheus = { version = "^0.13", default-features = false }
 
 tokio = { version = "1", features = ["full"] }

--- a/authentication-service/src/endpoints.rs
+++ b/authentication-service/src/endpoints.rs
@@ -7,6 +7,7 @@ use drogue_cloud_service_api::auth::device::authn::{
     AuthenticationRequest, AuthenticationResponse, AuthorizeGatewayRequest,
     AuthorizeGatewayResponse,
 };
+use drogue_cloud_service_api::webapp as actix_web;
 
 #[post("/auth")]
 pub async fn authenticate(

--- a/authentication-service/src/lib.rs
+++ b/authentication-service/src/lib.rs
@@ -4,6 +4,7 @@ pub mod service;
 use crate::service::PostgresAuthenticationService;
 use actix_web::{web, App, HttpServer};
 use drogue_cloud_service_api::health::HealthChecked;
+use drogue_cloud_service_api::webapp as actix_web;
 use drogue_cloud_service_common::{
     defaults,
     health::{HealthServer, HealthServerConfig},

--- a/authentication-service/src/main.rs
+++ b/authentication-service/src/main.rs
@@ -1,7 +1,7 @@
 use drogue_cloud_authentication_service::{run, Config};
 use drogue_cloud_service_common::app;
 
-#[actix_web::main]
+#[drogue_cloud_service_api::webapp::main]
 async fn main() -> anyhow::Result<()> {
     app!();
 }

--- a/authentication-service/src/service.rs
+++ b/authentication-service/src/service.rs
@@ -12,6 +12,7 @@ use drogue_cloud_database_common::{
     models::{app::*, device::*},
     Client, DatabaseService,
 };
+use drogue_cloud_service_api::webapp as actix_web;
 use drogue_cloud_service_api::{
     auth::device::authn::{
         self, AuthenticationRequest, AuthorizeGatewayRequest, GatewayOutcome, Outcome,

--- a/authentication-service/tests/basic.rs
+++ b/authentication-service/tests/basic.rs
@@ -3,6 +3,7 @@ mod common;
 use actix_web::{web, App};
 use drogue_cloud_authentication_service::{endpoints, service, WebData};
 use drogue_cloud_service_api::auth::device::authn::{AuthenticationRequest, Credential};
+use drogue_cloud_service_api::webapp as actix_web;
 use drogue_cloud_test_common::{client, db};
 use serde_json::{json, Value};
 use serial_test::serial;

--- a/authentication-service/tests/hashed.rs
+++ b/authentication-service/tests/hashed.rs
@@ -3,6 +3,7 @@ mod common;
 use actix_web::{web, App};
 use drogue_cloud_authentication_service::{endpoints, service, WebData};
 use drogue_cloud_service_api::auth::device::authn::{AuthenticationRequest, Credential};
+use drogue_cloud_service_api::webapp as actix_web;
 use drogue_cloud_test_common::{client, db};
 use rstest::rstest;
 use serde_json::{json, Value};

--- a/authentication-service/tests/x509.rs
+++ b/authentication-service/tests/x509.rs
@@ -3,6 +3,7 @@ mod common;
 use actix_web::{web, App};
 use drogue_cloud_authentication_service::{endpoints, service, WebData};
 use drogue_cloud_service_api::auth::device::authn::{AuthenticationRequest, Credential};
+use drogue_cloud_service_api::webapp as actix_web;
 use drogue_cloud_test_common::{client, db};
 use serde_json::{json, Value};
 use serial_test::serial;

--- a/coap-endpoint/Cargo.toml
+++ b/coap-endpoint/Cargo.toml
@@ -8,7 +8,6 @@ license = "Apache-2.0"
 
 [dependencies]
 actix-rt = "2"
-actix-web = "=4.0.0-beta.19"
 anyhow = "1"
 async-trait = "0.1"
 bytes = "1"

--- a/coap-endpoint/src/main.rs
+++ b/coap-endpoint/src/main.rs
@@ -1,7 +1,7 @@
 use drogue_cloud_coap_endpoint::{run, Config};
 use drogue_cloud_service_common::app;
 
-#[actix_web::main]
+#[drogue_cloud_service_api::webapp::main]
 async fn main() -> anyhow::Result<()> {
     app!();
 }

--- a/command-endpoint/Cargo.toml
+++ b/command-endpoint/Cargo.toml
@@ -10,8 +10,6 @@ license = "Apache-2.0"
 anyhow = "1"
 thiserror = "1"
 
-actix-web = "=4.0.0-beta.19" # we need v4 as we need tokio 1
-actix-web-httpauth = "=0.6.0-beta.7"
 actix-cors = "=0.6.0-beta.8"
 
 prometheus = { version = "^0.13", default-features = false }
@@ -38,7 +36,7 @@ log = "0.4"
 cloudevents-sdk = { version = "0.4", features = ["actix", "reqwest"] }
 
 drogue-cloud-endpoint-common = { path = "../endpoint-common" }
-drogue-cloud-integration-common = { path = "../integration-common", features = ["with_actix"] }
+drogue-cloud-integration-common = { path = "../integration-common" }
 drogue-cloud-service-common = { path = "../service-common" }
 drogue-cloud-service-api = { path = "../service-api" }
 

--- a/command-endpoint/src/lib.rs
+++ b/command-endpoint/src/lib.rs
@@ -4,6 +4,7 @@ use actix_cors::Cors;
 use actix_web::{get, middleware, web, App, HttpResponse, HttpServer, Responder};
 use drogue_client::openid::OpenIdTokenProvider;
 use drogue_cloud_endpoint_common::{sender::UpstreamSender, sink::KafkaSink};
+use drogue_cloud_service_api::webapp as actix_web;
 use drogue_cloud_service_api::{auth::user::authz::Permission, kafka::KafkaClientConfig};
 use drogue_cloud_service_common::{
     actix_auth::authentication::AuthN,

--- a/command-endpoint/src/main.rs
+++ b/command-endpoint/src/main.rs
@@ -1,7 +1,7 @@
 use drogue_cloud_command_endpoint::{run, Config};
 use drogue_cloud_service_common::app;
 
-#[actix_web::main]
+#[drogue_cloud_service_api::webapp::main]
 async fn main() -> anyhow::Result<()> {
     app!();
 }

--- a/command-endpoint/src/v1alpha1/mod.rs
+++ b/command-endpoint/src/v1alpha1/mod.rs
@@ -1,9 +1,10 @@
-use actix_web::{http::header, web, HttpResponse};
-use actix_web_httpauth::extractors::bearer::BearerAuth;
 use drogue_client::openid::TokenProvider;
 use drogue_client::{registry, Context};
 use drogue_cloud_endpoint_common::{error::HttpEndpointError, sender::UpstreamSender, sink::Sink};
 use drogue_cloud_integration_common::{self, commands::CommandOptions};
+use drogue_cloud_service_api::webapp::{
+    extractors::bearer::BearerAuth, http::header, web, HttpResponse,
+};
 use serde::Deserialize;
 
 #[derive(Clone, Debug, Deserialize)]

--- a/console-backend/Cargo.toml
+++ b/console-backend/Cargo.toml
@@ -8,10 +8,7 @@ license = "Apache-2.0"
 
 [dependencies]
 
-actix = "0.12.0"
-actix-web = "=4.0.0-beta.19" # we need v4 as we need tokio 1
 actix-cors = "=0.6.0-beta.8"
-actix-web-httpauth = "=0.6.0-beta.7"
 tokio-stream = { version = "0.1", features = ["time"] }
 prometheus = { version = "^0.13", default-features = false }
 
@@ -49,10 +46,10 @@ cloudevents-sdk = { version = "0.4", features = ["rdkafka"] }
 uuid = { version = "0.8", features = ["v4"] }
 
 drogue-cloud-console-common = { path = "../console-common" }
-drogue-cloud-service-api = { path = "../service-api", features = ["with_actix"] }
+drogue-cloud-service-api = { path = "../service-api" }
 drogue-cloud-event-common = { path = "../event-common" }
 drogue-cloud-service-common = { path = "../service-common" }
-drogue-cloud-integration-common = { path = "../integration-common", features = ["with_actix"] }
+drogue-cloud-integration-common = { path = "../integration-common" }
 drogue-cloud-access-token-service = { path = "../access-token-service" }
 
 drogue-client = "0.9.0-alpha.1"

--- a/console-backend/src/admin.rs
+++ b/console-backend/src/admin.rs
@@ -1,5 +1,6 @@
 use actix_web::HttpResponse;
 use drogue_cloud_service_api::auth::user::UserInformation;
+use drogue_cloud_service_api::webapp as actix_web;
 use serde_json::json;
 
 pub async fn whoami(user: UserInformation) -> Result<HttpResponse, actix_web::Error> {

--- a/console-backend/src/api.rs
+++ b/console-backend/src/api.rs
@@ -2,6 +2,7 @@ use crate::auth::OpenIdClient;
 use actix_web::{web, HttpRequest};
 use anyhow::Context;
 use drogue_cloud_service_api::endpoints::Endpoints;
+use drogue_cloud_service_api::webapp as actix_web;
 use serde_json::{json, Value};
 use std::borrow::Cow;
 

--- a/console-backend/src/auth.rs
+++ b/console-backend/src/auth.rs
@@ -2,6 +2,7 @@ use actix_web::{get, http, web, HttpResponse, Responder};
 use chrono::{DateTime, Utc};
 use drogue_cloud_console_common::UserInfo;
 use drogue_cloud_service_api::error::ErrorResponse;
+use drogue_cloud_service_api::webapp as actix_web;
 use openid::{biscuit::jws::Compact, Bearer, Configurable, StandardClaims, Token};
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;

--- a/console-backend/src/forward.rs
+++ b/console-backend/src/forward.rs
@@ -1,5 +1,6 @@
 use actix_web::{web, Error, HttpRequest, HttpResponse, ResponseError};
 use awc::Client;
+use drogue_cloud_service_api::webapp as actix_web;
 use std::fmt::Formatter;
 use url::Url;
 

--- a/console-backend/src/info.rs
+++ b/console-backend/src/info.rs
@@ -1,6 +1,7 @@
 use crate::demos::get_demos;
 use actix_web::{get, web, HttpResponse, Responder};
 use drogue_cloud_console_common::EndpointInformation;
+use drogue_cloud_service_api::webapp as actix_web;
 use drogue_cloud_service_api::{endpoints::Endpoints, version::DrogueVersion};
 use k8s_openapi::api::core::v1::ConfigMap;
 use kube::Api;

--- a/console-backend/src/lib.rs
+++ b/console-backend/src/lib.rs
@@ -16,6 +16,7 @@ use actix_web::{
 };
 use anyhow::Context;
 use drogue_cloud_access_token_service::{endpoints as keys, service::KeycloakAccessTokenService};
+use drogue_cloud_service_api::webapp as actix_web;
 use drogue_cloud_service_api::{endpoints::Endpoints, kafka::KafkaClientConfig};
 use drogue_cloud_service_common::{
     actix_auth::authentication::AuthN,

--- a/console-backend/src/main.rs
+++ b/console-backend/src/main.rs
@@ -1,7 +1,7 @@
 use drogue_cloud_console_backend::{run, Config};
 use drogue_cloud_service_common::{endpoints::create_endpoint_source, main};
 
-#[actix_web::main]
+#[drogue_cloud_service_api::webapp::main]
 async fn main() -> anyhow::Result<()> {
     main!({
         // the endpoint source we choose

--- a/console-common/Cargo.toml
+++ b/console-common/Cargo.toml
@@ -10,4 +10,4 @@ license = "Apache-2.0"
 anyhow = "1"
 
 serde = { version = "1", features = ["derive"] }
-drogue-cloud-service-api = { path = "../service-api" }
+drogue-cloud-service-api = { path = "../service-api", default-features = false }

--- a/console-frontend/Cargo.lock
+++ b/console-frontend/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
@@ -210,18 +210,6 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitvec"
-version = "0.19.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
 
 [[package]]
 name = "block-buffer"
@@ -493,6 +481,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "drogue-cloud-macros"
+version = "0.1.0"
+dependencies = [
+ "quote",
+]
+
+[[package]]
 name = "drogue-cloud-service-api"
 version = "0.9.0"
 dependencies = [
@@ -501,11 +496,11 @@ dependencies = [
  "base64-serde",
  "chrono",
  "drogue-client",
+ "drogue-cloud-macros",
  "indexmap",
  "lazy_static",
  "log",
  "md5",
- "nom 6.2.1",
  "regex",
  "serde",
  "serde_json",
@@ -632,12 +627,6 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
-
-[[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
@@ -1141,9 +1130,9 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "mime"
@@ -1169,19 +1158,6 @@ version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
- "lexical-core",
- "memchr",
- "version_check",
-]
-
-[[package]]
-name = "nom"
-version = "6.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5c51b9083a3c620fa67a2a635d1ce7d95b897e957d6b28ff9a5da960a103a6"
-dependencies = [
- "bitvec",
- "funty",
  "lexical-core",
  "memchr",
  "version_check",
@@ -1371,16 +1347,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "radium"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
-
-[[package]]
 name = "regex"
-version = "1.4.6"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a26af418b574bd56588335b3a3659a65725d4e636eb1016c2f9e3b38c7cc759"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1538,12 +1508,6 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "termcolor"
@@ -1812,12 +1776,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "wyz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
-
-[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1889,7 +1847,7 @@ dependencies = [
  "gloo 0.2.1",
  "js-sys",
  "log",
- "nom 5.1.2",
+ "nom",
  "serde",
  "serde_json",
  "wasm-bindgen",
@@ -1918,5 +1876,5 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ff6455529c0a731a8226f95546a5cbc625f346a7b4b06b3582d5ba5465d35d"
 dependencies = [
- "nom 5.1.2",
+ "nom",
 ]

--- a/console-frontend/Cargo.toml
+++ b/console-frontend/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1"
 thiserror = "1"
 
 drogue-cloud-console-common = { path = "../console-common" }
-drogue-cloud-service-api = { path = "../service-api" }
+drogue-cloud-service-api = { path = "../service-api", default-features = false }
 drogue-client = { version = "0.9.0-alpha.1", default-features = false }
 
 yew = "0.19"

--- a/database-common/Cargo.toml
+++ b/database-common/Cargo.toml
@@ -12,8 +12,6 @@ futures = "0.3"
 log = "0.4"
 thiserror = "1"
 
-actix-web = "=4.0.0-beta.19" # we need v4 as we need tokio 1
-
 serde_json = "1"
 serde = "1"
 chrono = "0.4"

--- a/database-common/src/error.rs
+++ b/database-common/src/error.rs
@@ -1,6 +1,6 @@
 use crate::models::GenerationError;
-use actix_web::{HttpResponse, ResponseError};
 use deadpool_postgres::PoolError;
+use drogue_cloud_service_api::webapp::{HttpResponse, ResponseError};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio_postgres::error::SqlState;

--- a/device-management-service/Cargo.toml
+++ b/device-management-service/Cargo.toml
@@ -11,9 +11,7 @@ anyhow = "1"
 
 async-trait = "0.1"
 
-actix-web = "=4.0.0-beta.19" # we need v4 as we need tokio 1
 actix-cors = "=0.6.0-beta.8"
-actix-web-httpauth = "=0.6.0-beta.7"
 prometheus = { version = "^0.13", default-features = false }
 
 http = "0.2"
@@ -43,7 +41,7 @@ reqwest = "0.11"
 
 drogue-cloud-database-common = { path = "../database-common" }
 drogue-cloud-service-common = { path = "../service-common" }
-drogue-cloud-service-api = { path = "../service-api", features = ["with_actix"] }
+drogue-cloud-service-api = { path = "../service-api" }
 drogue-cloud-registry-events = { path = "../registry-events" }
 drogue-cloud-admin-service = { path = "../admin-service"  }
 drogue-cloud-access-token-service = { path = "../access-token-service" }

--- a/device-management-service/src/endpoints/apps.rs
+++ b/device-management-service/src/endpoints/apps.rs
@@ -7,6 +7,7 @@ use crate::{
 use actix_web::{http::header, web, web::Json, HttpRequest, HttpResponse};
 use drogue_client::registry;
 use drogue_cloud_registry_events::EventSender;
+use drogue_cloud_service_api::webapp as actix_web;
 use drogue_cloud_service_api::{auth::user::UserInformation, labels::ParserError};
 use drogue_cloud_service_common::error::ServiceError;
 use drogue_cloud_service_common::keycloak::KeycloakClient;

--- a/device-management-service/src/endpoints/devices.rs
+++ b/device-management-service/src/endpoints/devices.rs
@@ -9,6 +9,7 @@ use crate::{
 use actix_web::{http::header, web, web::Json, HttpRequest, HttpResponse};
 use drogue_client::registry;
 use drogue_cloud_registry_events::EventSender;
+use drogue_cloud_service_api::webapp as actix_web;
 use drogue_cloud_service_api::{auth::user::UserInformation, labels::ParserError};
 use drogue_cloud_service_common::error::ServiceError;
 use drogue_cloud_service_common::keycloak::KeycloakClient;

--- a/device-management-service/src/endpoints/streamer.rs
+++ b/device-management-service/src/endpoints/streamer.rs
@@ -106,6 +106,7 @@ where
 mod test {
 
     use super::*;
+    use drogue_cloud_service_api::webapp as actix_web;
     use futures::{stream, TryStreamExt};
 
     #[tokio::test]

--- a/device-management-service/src/lib.rs
+++ b/device-management-service/src/lib.rs
@@ -9,6 +9,7 @@ use anyhow::Context;
 use drogue_cloud_admin_service::apps;
 use drogue_cloud_registry_events::sender::KafkaEventSender;
 use drogue_cloud_registry_events::sender::KafkaSenderConfig;
+use drogue_cloud_service_api::webapp as actix_web;
 use drogue_cloud_service_common::actix_auth::authentication::AuthN;
 use drogue_cloud_service_common::client::{UserAuthClient, UserAuthClientConfig};
 use drogue_cloud_service_common::openid::AuthenticatorConfig;

--- a/device-management-service/src/main.rs
+++ b/device-management-service/src/main.rs
@@ -1,7 +1,7 @@
 use drogue_cloud_device_management_service::{run, Config};
 use drogue_cloud_service_common::app;
 
-#[actix_web::main]
+#[drogue_cloud_service_api::webapp::main]
 async fn main() -> anyhow::Result<()> {
     app!();
 }

--- a/device-management-service/src/service/error.rs
+++ b/device-management-service/src/service/error.rs
@@ -2,6 +2,7 @@ use actix_web::{HttpResponse, ResponseError};
 use drogue_client::error::ErrorInformation;
 use drogue_cloud_database_common::{error::ServiceError, models::GenerationError};
 use drogue_cloud_registry_events::EventSenderError;
+use drogue_cloud_service_api::webapp as actix_web;
 use thiserror::Error;
 
 #[derive(Debug, Error)]

--- a/device-management-service/src/service/management/mod.rs
+++ b/device-management-service/src/service/management/mod.rs
@@ -3,7 +3,6 @@ use crate::{
     endpoints::params::DeleteParams,
     service::{error::PostgresManagementServiceError, PostgresManagementService},
 };
-use actix_web::ResponseError;
 use async_trait::async_trait;
 use chrono::Utc;
 use core::pin::Pin;
@@ -22,6 +21,7 @@ use drogue_cloud_registry_events::{Event, EventSender, SendEvent};
 use drogue_cloud_service_api::{
     auth::user::{authz::Permission, UserInformation},
     labels::LabelSelector,
+    webapp::ResponseError,
 };
 use drogue_cloud_service_common::keycloak::KeycloakClient;
 use futures::{future, Stream, TryStreamExt};

--- a/device-management-service/tests/apps.rs
+++ b/device-management-service/tests/apps.rs
@@ -17,6 +17,7 @@ use drogue_cloud_device_management_service::{
     WebData,
 };
 use drogue_cloud_registry_events::{mock::MockEventSender, Event};
+use drogue_cloud_service_api::webapp as actix_web;
 use drogue_cloud_service_common::keycloak::{
     mock::KeycloakAdminMock, KeycloakAdminClientConfig, KeycloakClient,
 };

--- a/device-management-service/tests/common.rs
+++ b/device-management-service/tests/common.rs
@@ -12,6 +12,7 @@ use drogue_cloud_database_common::{
 };
 use drogue_cloud_registry_events::Event;
 use drogue_cloud_service_api::auth::user::UserInformation;
+use drogue_cloud_service_api::webapp as actix_web;
 use drogue_cloud_service_common::openid::ExtendedClaims;
 use futures::TryStreamExt;
 use log::LevelFilter;
@@ -58,7 +59,7 @@ macro_rules! test {
         let mut $sender = sender;
         let $outbox = outbox;
 
-        let $app = actix_web::test::init_service(
+        let $app = drogue_cloud_service_api::webapp::test::init_service(
             app!(MockEventSender, KeycloakAdminMock, 16 * 1024, auth)
                 // for the management service
                 .app_data(data.clone())
@@ -68,8 +69,8 @@ macro_rules! test {
                 }))
                 .wrap_fn(|req, srv|{
                     log::warn!("Running test-user middleware");
-                    use actix_web::dev::Service;
-                    use actix_web::HttpMessage;
+                    use drogue_cloud_service_api::webapp::dev::Service;
+                    use drogue_cloud_service_api::webapp::HttpMessage;
                     {
                         let user: Option<&drogue_cloud_service_api::auth::user::UserInformation> = req.app_data();
                         if let Some(user) = user {

--- a/device-management-service/tests/devices.rs
+++ b/device-management-service/tests/devices.rs
@@ -22,6 +22,7 @@ use drogue_cloud_device_management_service::{
 };
 use drogue_cloud_registry_events::{mock::MockEventSender, Event};
 use drogue_cloud_service_api::auth::user::UserInformation;
+use drogue_cloud_service_api::webapp as actix_web;
 use drogue_cloud_service_common::keycloak::mock::KeycloakAdminMock;
 use drogue_cloud_service_common::keycloak::{KeycloakAdminClientConfig, KeycloakClient};
 use drogue_cloud_test_common::{client, db};

--- a/device-management-service/tests/transfer.rs
+++ b/device-management-service/tests/transfer.rs
@@ -11,6 +11,7 @@ use drogue_cloud_device_management_service::{
     WebData,
 };
 use drogue_cloud_registry_events::mock::MockEventSender;
+use drogue_cloud_service_api::webapp as actix_web;
 use drogue_cloud_service_common::keycloak::{
     mock::KeycloakAdminMock, KeycloakAdminClientConfig, KeycloakClient,
 };

--- a/endpoint-common/Cargo.toml
+++ b/endpoint-common/Cargo.toml
@@ -7,7 +7,6 @@ license = "Apache-2.0"
 
 [dependencies]
 
-actix-web = "=4.0.0-beta.19" # we need v4 as we need tokio 1
 actix-broker = "0.4.0"
 actix-tls = { version = "^3.0.0", optional = true }
 prometheus = { version = "^0.13", default-features = false }

--- a/endpoint-common/src/auth.rs
+++ b/endpoint-common/src/auth.rs
@@ -9,6 +9,7 @@ use drogue_cloud_service_api::auth::device::authn::{
     AuthenticationRequest, AuthenticationResponse, AuthorizeGatewayRequest,
     AuthorizeGatewayResponse, Credential,
 };
+use drogue_cloud_service_api::webapp as actix_web;
 use drogue_cloud_service_common::{
     client::ReqwestAuthenticatorClient, defaults, openid::TokenConfig,
 };

--- a/endpoint-common/src/error.rs
+++ b/endpoint-common/src/error.rs
@@ -1,5 +1,7 @@
-use actix_web::{error::PayloadError, http::StatusCode, HttpResponse, ResponseError};
 use drogue_client::error::ClientError;
+use drogue_cloud_service_api::webapp::{
+    error::PayloadError, http::StatusCode, HttpResponse, ResponseError,
+};
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 use std::fmt::Formatter;

--- a/endpoint-common/src/sender/mod.rs
+++ b/endpoint-common/src/sender/mod.rs
@@ -5,11 +5,11 @@ use crate::{
     sink::{Sink, SinkError, SinkTarget},
     EXT_PARTITIONKEY,
 };
-use actix_web::HttpResponse;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use cloudevents::{event::Data, Event, EventBuilder, EventBuilderV10};
 use drogue_client::registry;
+use drogue_cloud_service_api::webapp::HttpResponse;
 use drogue_cloud_service_api::{EXT_INSTANCE, EXT_SENDER};
 use drogue_cloud_service_common::{Id, IdInjector};
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};

--- a/endpoint-common/src/sender/process.rs
+++ b/endpoint-common/src/sender/process.rs
@@ -29,6 +29,7 @@ pub enum Error {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[allow(clippy::large_enum_variant)]
 pub enum Outcome {
     // Accept event
     Accepted(cloudevents::Event),

--- a/endpoint-common/src/x509.rs
+++ b/endpoint-common/src/x509.rs
@@ -1,4 +1,5 @@
 use actix_web::{dev::Payload, error, FromRequest, HttpMessage, HttpRequest};
+use drogue_cloud_service_api::webapp as actix_web;
 use futures_util::future::{ready, Ready};
 use tokio_rustls::rustls::Session;
 

--- a/http-endpoint/Cargo.toml
+++ b/http-endpoint/Cargo.toml
@@ -14,7 +14,6 @@ async-trait = "0.1"
 
 actix-rt = "2"
 actix-tls = "^3.0.0"
-actix-web = "=4.0.0-beta.19" # we need v4 as we need tokio 1
 actix-web-prom = { git = "https://github.com/nlopes/actix-web-prom", branch="nlopes/bump-to-actix-web-14" } #FIXME: use 0.6.0-beta.4 when available
 prometheus = { version = "^0.13", default-features = false }
 
@@ -64,5 +63,5 @@ features = ["v111"]
 
 [features]
 default = ["openssl"]
-openssl = ["actix-web/openssl"]
-rustls = ["actix-web/rustls"]
+openssl = ["drogue-cloud-service-api/openssl"]
+rustls = ["drogue-cloud-service-api/rustls"]

--- a/http-endpoint/src/command.rs
+++ b/http-endpoint/src/command.rs
@@ -3,11 +3,11 @@
 //! Contains actors that handles commands for HTTP endpoint
 
 use actix_rt::time::timeout;
-use actix_web::{http, web, HttpResponse};
 use drogue_cloud_endpoint_common::{
     command::{CommandFilter, Commands, Subscription},
     error::HttpEndpointError,
 };
+use drogue_cloud_service_api::webapp::{http, web, HttpResponse};
 use std::time::Duration;
 
 const HEADER_COMMAND: &str = "command";

--- a/http-endpoint/src/downstream.rs
+++ b/http-endpoint/src/downstream.rs
@@ -1,5 +1,4 @@
 use crate::command::wait_for_command;
-use actix_web::{web, HttpResponse};
 use async_trait::async_trait;
 use drogue_client::error::ErrorInformation;
 use drogue_cloud_endpoint_common::{
@@ -8,6 +7,7 @@ use drogue_cloud_endpoint_common::{
     sender::{DownstreamSender, Publish, PublishOutcome, Publisher, DOWNSTREAM_EVENTS_COUNTER},
     sink::Sink,
 };
+use drogue_cloud_service_api::webapp::{web, HttpResponse};
 
 #[async_trait]
 pub trait HttpCommandSender {

--- a/http-endpoint/src/lib.rs
+++ b/http-endpoint/src/lib.rs
@@ -18,6 +18,7 @@ use drogue_cloud_endpoint_common::{
     auth::DeviceAuthenticator, sender::DownstreamSender, sink::KafkaSink,
 };
 use drogue_cloud_service_api::kafka::KafkaClientConfig;
+use drogue_cloud_service_api::webapp as actix_web;
 use drogue_cloud_service_common::{
     defaults,
     health::{HealthServer, HealthServerConfig},

--- a/http-endpoint/src/main.rs
+++ b/http-endpoint/src/main.rs
@@ -1,7 +1,7 @@
 use drogue_cloud_http_endpoint::{run, Config};
 use drogue_cloud_service_common::app;
 
-#[actix_web::main]
+#[drogue_cloud_service_api::webapp::main]
 async fn main() -> anyhow::Result<()> {
     app!();
 }

--- a/http-endpoint/src/telemetry.rs
+++ b/http-endpoint/src/telemetry.rs
@@ -1,5 +1,4 @@
 use crate::downstream::HttpCommandSender;
-use actix_web::{http::header, web, HttpResponse};
 use drogue_cloud_endpoint_common::{
     auth::DeviceAuthenticator,
     command::Commands,
@@ -9,6 +8,7 @@ use drogue_cloud_endpoint_common::{
     x509::ClientCertificateChain,
 };
 use drogue_cloud_service_api::auth::device::authn;
+use drogue_cloud_service_api::webapp::{http::header, web, HttpResponse};
 use serde::Deserialize;
 
 #[derive(Deserialize)]

--- a/http-endpoint/src/ttn/mod.rs
+++ b/http-endpoint/src/ttn/mod.rs
@@ -5,7 +5,6 @@ pub use v2::*;
 pub use v3::*;
 
 use crate::telemetry::PublishCommonOptions;
-use actix_web::{web, HttpResponse};
 use chrono::{DateTime, Utc};
 use drogue_client::registry;
 use drogue_cloud_endpoint_common::{
@@ -16,6 +15,7 @@ use drogue_cloud_endpoint_common::{
     x509::ClientCertificateChain,
 };
 use drogue_cloud_service_api::auth::device::authn;
+use drogue_cloud_service_api::webapp::{web, HttpResponse};
 use serde_json::Value;
 use std::collections::HashMap;
 

--- a/http-endpoint/src/ttn/v2.rs
+++ b/http-endpoint/src/ttn/v2.rs
@@ -2,7 +2,6 @@ use crate::{
     telemetry::PublishCommonOptions,
     ttn::{publish_uplink, Uplink},
 };
-use actix_web::{web, HttpResponse};
 use drogue_cloud_endpoint_common::{
     auth::DeviceAuthenticator,
     error::{EndpointError, HttpEndpointError},
@@ -10,6 +9,7 @@ use drogue_cloud_endpoint_common::{
     sink::Sink,
     x509::ClientCertificateChain,
 };
+use drogue_cloud_service_api::webapp::{web, HttpResponse};
 use drogue_ttn::v2;
 
 pub async fn publish_v2<S>(

--- a/http-endpoint/src/ttn/v3.rs
+++ b/http-endpoint/src/ttn/v3.rs
@@ -2,7 +2,6 @@ use crate::{
     telemetry::PublishCommonOptions,
     ttn::{publish_uplink, Uplink},
 };
-use actix_web::{web, HttpResponse};
 use drogue_cloud_endpoint_common::{
     auth::DeviceAuthenticator,
     error::{EndpointError, HttpEndpointError},
@@ -10,6 +9,7 @@ use drogue_cloud_endpoint_common::{
     sink::Sink,
     x509::ClientCertificateChain,
 };
+use drogue_cloud_service_api::webapp::{web, HttpResponse};
 use drogue_ttn::v3::{Message, Payload};
 
 pub async fn publish_v3<S>(

--- a/integration-common/Cargo.toml
+++ b/integration-common/Cargo.toml
@@ -32,11 +32,6 @@ drogue-cloud-event-common = { path = "../event-common" }
 
 drogue-client = "0.9.0-alpha.1"
 
-actix-web = { version = "=4.0.0-beta.19", optional = true } # we need v4 as we need tokio 1
-
 [dependencies.rdkafka]
 version = "0.25"
 features = ["ssl", "sasl"]
-
-[features]
-with_actix = ["actix-web"]

--- a/integration-common/src/commands/mod.rs
+++ b/integration-common/src/commands/mod.rs
@@ -1,12 +1,12 @@
 mod sender;
 
-use actix_web::HttpResponse;
 use drogue_client::{registry, Translator};
 use drogue_cloud_endpoint_common::{
     error::HttpEndpointError,
     sender::{Publish, PublishOptions, PublishOutcome, Publisher, UpstreamSender},
     sink::Sink,
 };
+use drogue_cloud_service_api::webapp::HttpResponse;
 use serde::Deserialize;
 
 #[derive(Deserialize)]

--- a/integration-common/src/commands/sender/mod.rs
+++ b/integration-common/src/commands/sender/mod.rs
@@ -3,9 +3,9 @@ mod ttnv2;
 mod ttnv3;
 
 use crate::commands::CommandOptions;
-use actix_web::web;
 use async_trait::async_trait;
 use drogue_client::registry;
+use drogue_cloud_service_api::webapp::web;
 use reqwest::{
     header::{HeaderName, HeaderValue},
     Response, StatusCode,

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "drogue-cloud-macros"
+version = "0.1.0"
+edition = "2021"
+authors = ["Jim Crossley <jcrossley@redhat.com>"]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1"

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,0 +1,14 @@
+use proc_macro::TokenStream;
+use quote::quote;
+
+/// Lifted from actix-web-codegen
+#[proc_macro_attribute]
+pub fn main(_: TokenStream, item: TokenStream) -> TokenStream {
+    let mut output: TokenStream = (quote! {
+        #[::drogue_cloud_service_api::webapp::rt::main(system = "::drogue_cloud_service_api::webapp::rt::System")]
+    })
+    .into();
+
+    output.extend(item);
+    output
+}

--- a/mqtt-integration/Cargo.toml
+++ b/mqtt-integration/Cargo.toml
@@ -53,7 +53,7 @@ drogue-cloud-endpoint-common = { path = "../endpoint-common" }
 drogue-cloud-event-common = { path = "../event-common" }
 drogue-cloud-service-api = { path = "../service-api" }
 drogue-cloud-service-common = { path = "../service-common" }
-drogue-cloud-integration-common = { path = "../integration-common", features = ["actix-web"] }
+drogue-cloud-integration-common = { path = "../integration-common" }
 drogue-client = "0.9.0-alpha.1"
 
 [dependencies.open-ssl]

--- a/service-api/Cargo.toml
+++ b/service-api/Cargo.toml
@@ -23,9 +23,12 @@ url = "2"
 md5 = "0.7"
 
 drogue-client = { version = "0.9.0-alpha.1", default-features = false }
+drogue-cloud-macros = { path = "../macros" }
 
 actix-web = { version = "=4.0.0-beta.19", optional = true } # we need v4 as we need tokio 1
-futures = { version = "0.3", optional = true }
+actix-http = { version = "=3.0.0-beta.18", optional = true } # FIXME: temporary intermediate
+actix-web-httpauth = { version = "=0.6.0-beta.7", optional = true }
+actix-rt = { version = "2", optional = true }
 
 nom = { version = "6", optional = true }
 
@@ -35,5 +38,7 @@ rdkafka = { version = "*", optional = true }
 config = "0.11"
 
 [features]
-default = ["nom"]
-with_actix = ["actix-web", "futures"]
+default = ["nom", "actix"]
+actix = ["actix-web", "actix-web-httpauth", "actix-rt"]
+rustls = ["actix-web/rustls"]
+openssl = ["actix-web/openssl"]

--- a/service-api/src/auth/user/mod.rs
+++ b/service-api/src/auth/user/mod.rs
@@ -3,9 +3,6 @@ pub mod authz;
 
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "with_actix")]
-use actix_web::HttpMessage;
-
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct UserDetails {
     pub user_id: String,
@@ -47,12 +44,13 @@ impl UserInformation {
     }
 }
 
-#[cfg(feature = "with_actix")]
+#[cfg(feature = "actix")]
 impl actix_web::FromRequest for UserInformation {
     type Error = actix_web::Error;
     type Future = core::future::Ready<Result<Self, Self::Error>>;
 
     fn from_request(req: &actix_web::HttpRequest, _: &mut actix_web::dev::Payload) -> Self::Future {
+        use actix_web::HttpMessage;
         match req.extensions().get::<UserInformation>() {
             Some(user) => core::future::ready(Ok(user.clone())),
             None => core::future::ready(Ok(UserInformation::Anonymous)),

--- a/service-api/src/labels/mod.rs
+++ b/service-api/src/labels/mod.rs
@@ -4,6 +4,7 @@ mod parser;
 #[cfg(feature = "nom")]
 pub use parser::*;
 
+#[cfg(feature = "nom")]
 use std::convert::TryFrom;
 
 #[derive(Default)]

--- a/service-api/src/lib.rs
+++ b/service-api/src/lib.rs
@@ -11,3 +11,6 @@ pub mod token;
 pub mod version;
 
 pub use id::*;
+
+#[cfg(feature = "actix")]
+pub mod webapp;

--- a/service-api/src/webapp/mod.rs
+++ b/service-api/src/webapp/mod.rs
@@ -1,0 +1,5 @@
+pub use actix_rt as rt;
+pub use actix_web::*;
+pub use actix_web_httpauth::extractors;
+pub use actix_web_httpauth::middleware::HttpAuthentication;
+pub use drogue_cloud_macros::main;

--- a/service-common/Cargo.toml
+++ b/service-common/Cargo.toml
@@ -11,11 +11,7 @@ config = "0.11"
 anyhow = "1"
 
 actix = { version = "0.12.0", default-features = false }
-actix-http = "=3.0.0-beta.18" # FIXME: temporary intermediate
-actix-web = "=4.0.0-beta.19" # we need v4 as we need tokio 1
-actix-web-httpauth = "=0.6.0-beta.7"
 actix-service = "2"
-actix-rt = "2"
 ntex = { version = "0.5", features = ["tokio"] }
 http = "0.2"
 actix-web-prom = { git = "https://github.com/nlopes/actix-web-prom", branch="nlopes/bump-to-actix-web-14" } #FIXME: use 0.6.0-beta.4 when available
@@ -62,4 +58,4 @@ tokio = { version = "1", features = ["full"] }
 
 [features]
 default = ["rustls"]
-rustls = ["rust_tls", "webpki", "reqwest/rustls-tls"]
+rustls = ["rust_tls", "webpki", "reqwest/rustls-tls" ]

--- a/service-common/src/actix_auth/authentication/middleware.rs
+++ b/service-common/src/actix_auth/authentication/middleware.rs
@@ -1,5 +1,5 @@
 use actix_service::{Service, Transform};
-use actix_web::{
+use drogue_cloud_service_api::webapp::{
     dev::{ServiceRequest, ServiceResponse},
     web::Query,
     Error, HttpMessage,
@@ -8,9 +8,9 @@ use actix_web::{
 use crate::actix_auth::authentication::{AuthN, Credentials, UsernameAndToken};
 use crate::error::ServiceError;
 
-use actix_web_httpauth::extractors::basic::BasicAuth;
-use actix_web_httpauth::extractors::bearer::BearerAuth;
-use actix_web_httpauth::extractors::AuthExtractor;
+use drogue_cloud_service_api::webapp::extractors::basic::BasicAuth;
+use drogue_cloud_service_api::webapp::extractors::bearer::BearerAuth;
+use drogue_cloud_service_api::webapp::extractors::AuthExtractor;
 use futures_util::future;
 use futures_util::future::LocalBoxFuture;
 use serde::Deserialize;

--- a/service-common/src/actix_auth/authorization/middleware.rs
+++ b/service-common/src/actix_auth/authorization/middleware.rs
@@ -1,5 +1,5 @@
 use actix_service::{Service, Transform};
-use actix_web::{
+use drogue_cloud_service_api::webapp::{
     dev::{ServiceRequest, ServiceResponse},
     Error, HttpMessage,
 };

--- a/service-common/src/auth/service/mock/auth.rs
+++ b/service-common/src/auth/service/mock/auth.rs
@@ -2,7 +2,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use actix_service::{Service, Transform};
-use actix_web::{dev::ServiceRequest, dev::ServiceResponse, Error};
+use drogue_cloud_service_api::webapp::{dev::ServiceRequest, dev::ServiceResponse, Error};
 use futures::future::{ok, Ready};
 use futures::Future;
 

--- a/service-common/src/auth/service/mod.rs
+++ b/service-common/src/auth/service/mod.rs
@@ -7,8 +7,9 @@ use crate::{
     openid::{Authenticator, AuthenticatorError},
 };
 use actix_web::{dev::ServiceRequest, HttpMessage};
-use actix_web_httpauth::extractors::bearer::BearerAuth;
 use drogue_cloud_service_api::auth::user::UserInformation;
+use drogue_cloud_service_api::webapp as actix_web;
+use drogue_cloud_service_api::webapp::extractors::bearer::BearerAuth;
 
 pub async fn openid_validator<F>(
     req: ServiceRequest,
@@ -41,7 +42,7 @@ where
 #[macro_export]
 macro_rules! openid_auth {
     ($req:ident -> $($extract:tt)* ) => {
-	actix_web::middleware::Compat::new(actix_web_httpauth::middleware::HttpAuthentication::bearer(|req, auth| $crate::auth::openid_validator(req, auth, |$req| $($extract)*)))
+	actix_web::middleware::Compat::new(drogue_cloud_service_api::webapp::HttpAuthentication::bearer(|req, auth| $crate::auth::openid_validator(req, auth, |$req| $($extract)*)))
     };
 }
 

--- a/service-common/src/error.rs
+++ b/service-common/src/error.rs
@@ -1,6 +1,6 @@
-use actix_web::{HttpResponse, ResponseError};
 use drogue_client::error::ClientError;
 use drogue_cloud_service_api::error::ErrorResponse;
+use drogue_cloud_service_api::webapp::{HttpResponse, ResponseError};
 use thiserror::Error;
 
 #[derive(Debug, Error)]

--- a/service-common/src/health.rs
+++ b/service-common/src/health.rs
@@ -2,6 +2,7 @@ use crate::defaults;
 use actix_web::HttpServer;
 use actix_web_prom::PrometheusMetricsBuilder;
 use drogue_cloud_service_api::health::{HealthCheckError, HealthChecked};
+use drogue_cloud_service_api::webapp as actix_web;
 use futures::StreamExt;
 use prometheus::Registry;
 use serde::Deserialize;

--- a/service-common/src/keycloak/error.rs
+++ b/service-common/src/keycloak/error.rs
@@ -1,6 +1,5 @@
-use actix_web::http::StatusCode;
-use actix_web::{HttpResponse, ResponseError};
 use drogue_cloud_service_api::error::ErrorResponse;
+use drogue_cloud_service_api::webapp::{http::StatusCode, HttpResponse, ResponseError};
 use keycloak::KeycloakError;
 use thiserror::Error;
 

--- a/user-auth-service/Cargo.toml
+++ b/user-auth-service/Cargo.toml
@@ -12,8 +12,6 @@ license = "Apache-2.0"
 
 anyhow = "1"
 
-actix-web = "=4.0.0-beta.19" # we need v4 as we need tokio 1
-actix-web-httpauth = "=0.6.0-beta.7"
 prometheus = { version = "^0.13", default-features = false }
 
 tokio = { version = "1", features = ["full"] }

--- a/user-auth-service/src/endpoints.rs
+++ b/user-auth-service/src/endpoints.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use actix_web::{post, web, HttpResponse};
 use drogue_cloud_service_api::auth::user::authz::{AuthorizationRequest, AuthorizationResponse};
+use drogue_cloud_service_api::webapp as actix_web;
 
 #[post("/authz")]
 /// Endpoint to authorize a user operation.

--- a/user-auth-service/src/lib.rs
+++ b/user-auth-service/src/lib.rs
@@ -5,6 +5,7 @@ use actix_web::{web, App, HttpServer};
 use drogue_cloud_access_token_service::{
     endpoints::WebData as KeycloakWebData, service::KeycloakAccessTokenService,
 };
+use drogue_cloud_service_api::webapp as actix_web;
 use drogue_cloud_service_common::{
     defaults,
     health::{HealthServer, HealthServerConfig},

--- a/user-auth-service/src/main.rs
+++ b/user-auth-service/src/main.rs
@@ -1,7 +1,7 @@
 use drogue_cloud_service_common::{keycloak::client::KeycloakAdminClient, main};
 use drogue_cloud_user_auth_service::{run, Config};
 
-#[actix_web::main]
+#[drogue_cloud_service_api::webapp::main]
 async fn main() -> anyhow::Result<()> {
     main!(run::<KeycloakAdminClient>(Config::from_env()?).await)
 }

--- a/user-auth-service/src/service.rs
+++ b/user-auth-service/src/service.rs
@@ -8,6 +8,7 @@ use drogue_cloud_database_common::{
     DatabaseService,
 };
 use drogue_cloud_service_api::auth::user::{UserDetails, UserInformation};
+use drogue_cloud_service_api::webapp as actix_web;
 use drogue_cloud_service_api::{
     auth::user::authz::{AuthorizationRequest, Outcome},
     health::{HealthCheckError, HealthChecked},

--- a/user-auth-service/tests/basic.rs
+++ b/user-auth-service/tests/basic.rs
@@ -2,6 +2,7 @@ mod common;
 
 use actix_web::{web, App};
 use drogue_cloud_service_api::auth::user::authz::{AuthorizationRequest, Permission};
+use drogue_cloud_service_api::webapp as actix_web;
 use drogue_cloud_test_common::{client, db};
 use drogue_cloud_user_auth_service::{endpoints, service, WebData};
 use serde_json::json;

--- a/user-auth-service/tests/members.rs
+++ b/user-auth-service/tests/members.rs
@@ -2,6 +2,7 @@ mod common;
 
 use actix_web::{web, App};
 use drogue_cloud_service_api::auth::user::authz::{AuthorizationRequest, Permission};
+use drogue_cloud_service_api::webapp as actix_web;
 use drogue_cloud_test_common::{client, db};
 use drogue_cloud_user_auth_service::{endpoints, service, WebData};
 use serde_json::json;

--- a/websocket-integration/Cargo.toml
+++ b/websocket-integration/Cargo.toml
@@ -10,10 +10,7 @@ license = "Apache-2.0"
 anyhow = "1"
 
 actix = { version = "0.12.0"}
-actix-http = "=3.0.0-beta.18"
-actix-web = "=4.0.0-beta.19"
 actix-web-actors = "=4.0.0-beta.10"
-actix-web-httpauth = "=0.6.0-beta.7"
 prometheus = { version = "^0.13", default-features = false }
 
 dotenv = "0.15"
@@ -35,5 +32,5 @@ url = "2"
 
 drogue-client = "0.9.0-alpha.1"
 drogue-cloud-service-common = { path = "../service-common" }
-drogue-cloud-integration-common = { path = "../integration-common", features = ["actix-web"] }
+drogue-cloud-integration-common = { path = "../integration-common" }
 drogue-cloud-service-api = { path = "../service-api" }

--- a/websocket-integration/src/lib.rs
+++ b/websocket-integration/src/lib.rs
@@ -6,6 +6,7 @@ mod wshandler;
 use crate::service::Service;
 use actix::Actor;
 use actix_web::{web, App, HttpServer};
+use drogue_cloud_service_api::webapp as actix_web;
 use drogue_cloud_service_api::{auth::user::authz::Permission, kafka::KafkaClientConfig};
 use drogue_cloud_service_common::{
     actix_auth::authentication::AuthN,

--- a/websocket-integration/src/main.rs
+++ b/websocket-integration/src/main.rs
@@ -1,7 +1,7 @@
 use drogue_cloud_service_common::app;
 use drogue_cloud_websocket_integration::{run, Config};
 
-#[actix_web::main]
+#[drogue_cloud_service_api::webapp::main]
 async fn main() -> anyhow::Result<()> {
     app!();
 }

--- a/websocket-integration/src/route.rs
+++ b/websocket-integration/src/route.rs
@@ -7,6 +7,7 @@ use actix_web::{
 };
 use actix_web_actors::ws;
 use drogue_client::openid::OpenIdTokenProvider;
+use drogue_cloud_service_api::webapp as actix_web;
 use serde::Deserialize;
 
 #[derive(Deserialize, Debug)]


### PR DESCRIPTION
The primary motivation for this PR is to declare the `actix-web` version that all the drogue-cloud crates depend on in a single place. In this PR, that place is `service-api/Cargo.toml`.
 
Initially, this is mostly re-exporting actix-web abstractions from the `service-api` crate, but it can evolve to be smarter and more suited to how the drogue web apps use actix.

The biggest challenge was the `actix-web::main` proc macro, since it generates code assuming actix-web is declared as a dep. Re-exporting it from `service-api` required implementing our own `proc-macro=true` crate: `macros`. Ugh.

The new `macros` crate could possibly justify its existence by moving the `service-common/src/app.rs` stuff over to it, but that's for another PR.
