### PR TITLE
Feature/complex topic names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1685,7 +1685,7 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 [[package]]
 name = "drogue-client"
 version = "0.9.0-alpha.1"
-source = "git+https://github.com/drogue-iot/drogue-client?rev=1449b9a6f0741a37e6c96c030a3cde3d40b8bc0b#1449b9a6f0741a37e6c96c030a3cde3d40b8bc0b"
+source = "git+https://github.com/drogue-iot/drogue-client?rev=32d29e670abf7a1c9ebb99d3cadda64bcf1748f6#32d29e670abf7a1c9ebb99d3cadda64bcf1748f6"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2239,6 +2239,7 @@ dependencies = [
  "rustls 0.20.2",
  "serde 1.0.136",
  "serde_json",
+ "thiserror",
  "tokio 1.16.1",
  "tracing",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ testcontainers = { git = "https://github.com/testcontainers/testcontainers-rs", 
 #reqwest = { git = "https://github.com/ctron/reqwest", branch = "feature/basic_auth_wasm_1" }
 #drogue-ttn = { git = "https://github.com/drogue-iot/drogue-ttn", rev = "cf0338a344309815f0f05e0d7d76acb712445175" } # FIXME: awaiting release
 
-drogue-client = { git = "https://github.com/drogue-iot/drogue-client", rev = "1449b9a6f0741a37e6c96c030a3cde3d40b8bc0b" } # FIXME: awaiting release
+drogue-client = { git = "https://github.com/drogue-iot/drogue-client", rev = "32d29e670abf7a1c9ebb99d3cadda64bcf1748f6" } # FIXME: awaiting release
 #drogue-client = { path = "../drogue-client" }
 
 operator-framework = { git = "https://github.com/ctron/operator-framework", rev = "d4415ccbc03417942f38573a0e164143bae9a25e" } # FIXME: awaiting release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ drogue-client = { git = "https://github.com/drogue-iot/drogue-client", rev = "14
 
 operator-framework = { git = "https://github.com/ctron/operator-framework", rev = "d4415ccbc03417942f38573a0e164143bae9a25e" } # FIXME: awaiting release
 
-actix-web-prom = { git = "https://github.com/nlopes/actix-web-prom", branch="nlopes/bump-to-actix-web-14" } #FIXME: use 0.6.0-beta.4 when available
+actix-web-prom = { git = "https://github.com/nlopes/actix-web-prom", branch = "nlopes/bump-to-actix-web-14" } #FIXME: use 0.6.0-beta.4 when available
 
 # required du to missing "beta" versions for more recent "beta" actix versions
 cloudevents-sdk = { git = "https://github.com/cloudevents/sdk-rust", branch = "actix-web-4.0.0-beta.19" } # FIXME: pre-release branch

--- a/mqtt-common/src/error.rs
+++ b/mqtt-common/src/error.rs
@@ -27,6 +27,7 @@ pub enum ServerError {
     AuthenticationFailed,
     NotAuthorized,
     PublishError(PublishError),
+    Configuration(String),
 }
 
 impl From<PublishError> for ServerError {

--- a/mqtt-endpoint/Cargo.toml
+++ b/mqtt-endpoint/Cargo.toml
@@ -41,6 +41,7 @@ uuid = { version = "0.8", features = ["v4"] }
 env_logger = "0.9"
 dotenv = "0.15"
 log = "0.4"
+thiserror = "1"
 
 webpki = "0.21"
 

--- a/mqtt-endpoint/src/service/app.rs
+++ b/mqtt-endpoint/src/service/app.rs
@@ -1,3 +1,4 @@
+use crate::service::session::Dialect::DrogueV1;
 use crate::{auth::DeviceAuthenticator, config::EndpointConfig, service::session::Session};
 use async_trait::async_trait;
 use drogue_cloud_endpoint_common::{
@@ -100,6 +101,7 @@ where
                     self.downstream.clone(),
                     connect.sink(),
                     application,
+                    DrogueV1,
                     device,
                     self.commands.clone(),
                 );

--- a/mqtt-endpoint/src/service/session/dialect.rs
+++ b/mqtt-endpoint/src/service/session/dialect.rs
@@ -1,0 +1,196 @@
+use drogue_client::registry::v1::MqttDialect;
+use thiserror::Error;
+
+/// A topic parser for the default session.
+pub trait DefaultTopicParser {
+    fn parse_publish<'a>(&self, path: &'a str) -> Result<ParsedTopic<'a>, ParseError>;
+}
+
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+pub enum ParseError {
+    #[error("Topic syntax error")]
+    Syntax,
+    #[error("Empty topic error")]
+    Empty,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ParsedTopic<'a> {
+    pub channel: &'a str,
+    pub device: Option<&'a str>,
+}
+
+impl DefaultTopicParser for MqttDialect {
+    fn parse_publish<'a>(&self, path: &'a str) -> Result<ParsedTopic<'a>, ParseError> {
+        match &self {
+            Self::DrogueV1 => {
+                // This should mimic the behavior of the current parser
+                let topic = path.split('/').collect::<Vec<_>>();
+                log::debug!("Topic: {:?}", topic);
+
+                match topic.as_slice() {
+                    [""] => Err(ParseError::Empty),
+                    [channel] => Ok(ParsedTopic {
+                        channel,
+                        device: None,
+                    }),
+                    [channel, as_device] => Ok(ParsedTopic {
+                        channel,
+                        device: Some(as_device),
+                    }),
+                    _ => Err(ParseError::Syntax),
+                }
+            }
+            Self::PlainTopic {
+                device_prefix: false,
+            } => {
+                // Plain topic, just take the complete path
+                match path {
+                    "" => Err(ParseError::Empty),
+                    path => Ok(ParsedTopic {
+                        channel: path,
+                        device: None,
+                    }),
+                }
+            }
+            Self::PlainTopic {
+                device_prefix: true,
+            } => {
+                // Plain topic (with device prefix). Strip the device, and then just take the complete path
+
+                let topic = path.split_once('/');
+                log::debug!("Topic: {:?}", topic);
+
+                match topic {
+                    // No topic at all
+                    None if path == "" => Err(ParseError::Empty),
+                    None => Err(ParseError::Syntax),
+                    Some(("", path)) => Ok(ParsedTopic {
+                        channel: path,
+                        device: None,
+                    }),
+                    Some((device, path)) => Ok(ParsedTopic {
+                        channel: path,
+                        device: Some(device),
+                    }),
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use drogue_client::registry::v1::MqttSpec;
+    use serde_json::json;
+
+    #[test]
+    fn test_v1() {
+        let spec: MqttSpec = serde_json::from_value(json!({"dialect":{
+            "type": "drogue/v1"
+        }}))
+        .unwrap();
+
+        assert_parse(&spec, "", Err(ParseError::Empty));
+        // channel for self device
+        assert_parse(
+            &spec,
+            "foo",
+            Ok(ParsedTopic {
+                channel: "foo",
+                device: None,
+            }),
+        );
+        // channel for another device
+        assert_parse(
+            &spec,
+            "foo/device",
+            Ok(ParsedTopic {
+                channel: "foo",
+                device: Some("device"),
+            }),
+        );
+    }
+
+    #[test]
+    fn test_plain() {
+        let spec: MqttSpec = serde_json::from_value(json!({"dialect":{
+            "type": "plainTopic"
+        }}))
+        .unwrap();
+
+        assert_parse(&spec, "", Err(ParseError::Empty));
+
+        // just take the topic, the device is always `None`
+
+        assert_parse(
+            &spec,
+            "foo",
+            Ok(ParsedTopic {
+                channel: "foo",
+                device: None,
+            }),
+        );
+        assert_parse(
+            &spec,
+            "foo/bar",
+            Ok(ParsedTopic {
+                channel: "foo/bar",
+                device: None,
+            }),
+        );
+        assert_parse(
+            &spec,
+            "/bar",
+            Ok(ParsedTopic {
+                channel: "/bar",
+                device: None,
+            }),
+        );
+    }
+
+    #[test]
+    fn test_plain_prefix() {
+        let spec: MqttSpec = serde_json::from_value(json!({"dialect":{
+            "type": "plainTopic",
+            "devicePrefix": true,
+        }}))
+        .unwrap();
+
+        assert_parse(&spec, "", Err(ParseError::Empty));
+        // we need at least two segments
+        assert_parse(&spec, "foo", Err(ParseError::Syntax));
+        // check that device comes first
+        assert_parse(
+            &spec,
+            "foo/bar",
+            Ok(ParsedTopic {
+                channel: "bar",
+                device: Some("foo"),
+            }),
+        );
+        // device may be empty though
+        assert_parse(
+            &spec,
+            "/bar",
+            Ok(ParsedTopic {
+                channel: "bar",
+                device: None,
+            }),
+        );
+        // longer topic
+        assert_parse(
+            &spec,
+            "foo/bar/baz//bam/bum",
+            Ok(ParsedTopic {
+                channel: "bar/baz//bam/bum",
+                device: Some("foo"),
+            }),
+        );
+    }
+
+    fn assert_parse(spec: &MqttSpec, path: &str, expected: Result<ParsedTopic, ParseError>) {
+        assert_eq!(spec.dialect.parse_publish(path), expected);
+    }
+}

--- a/mqtt-endpoint/src/service/session/mod.rs
+++ b/mqtt-endpoint/src/service/session/mod.rs
@@ -28,11 +28,10 @@ use std::{
 };
 use tracing::instrument;
 
-
 #[derive(Clone)]
 pub enum Dialect {
     DrogueV1,
-    LongTopicDialect
+    LongTopicDialect,
 }
 
 struct ParseError;
@@ -42,9 +41,7 @@ struct ParsedTopic<'a> {
     device: Option<&'a str>,
 }
 
-
 impl Dialect {
-
     fn handle<'a>(&self, path: &'a str) -> Result<ParsedTopic<'a>, ParseError> {
         match &self {
             Self::DrogueV1 => {
@@ -53,15 +50,23 @@ impl Dialect {
                 log::debug!("Topic: {:?}", topic);
 
                 match topic.as_slice() {
-                    [channel] => Ok(ParsedTopic {channel: channel, device: None}),
-                    [channel, as_device] => Ok(ParsedTopic {channel: channel, device: Some(as_device)}),
+                    [channel] => Ok(ParsedTopic {
+                        channel: channel,
+                        device: None,
+                    }),
+                    [channel, as_device] => Ok(ParsedTopic {
+                        channel: channel,
+                        device: Some(as_device),
+                    }),
                     _ => Err(ParseError),
                 }
-
-            },
+            }
             Self::LongTopicDialect => {
                 // New Parsing strategy, just take the complete path
-                Ok(ParsedTopic { channel: path, device: None })
+                Ok(ParsedTopic {
+                    channel: path,
+                    device: None,
+                })
             }
         }
     }
@@ -69,8 +74,8 @@ impl Dialect {
 
 #[derive(Clone)]
 pub struct Session<S>
-    where
-        S: Sink,
+where
+    S: Sink,
 {
     sender: DownstreamSender<S>,
     application: registry::v1::Application,
@@ -85,8 +90,8 @@ pub struct Session<S>
 }
 
 impl<S> Session<S>
-    where
-        S: Sink,
+where
+    S: Sink,
 {
     pub fn new(
         config: &EndpointConfig,
@@ -141,7 +146,7 @@ impl<S> Session<S>
                     self.sink.clone(),
                     force_device,
                 )
-                    .await;
+                .await;
                 entry.insert(subscription);
             }
         }
@@ -152,46 +157,37 @@ impl<S> Session<S>
         &self,
         publish: &Publish<'_>,
     ) -> Result<(String, Arc<registry::v1::Device>), PublishError> {
-
-
         // TODO this should be removed and is just there as an example
 
         match &self.dialect.handle(publish.topic().path()) {
-            Ok(topic) => {
-                match topic.device {
-                    Some(device) => {
-                        self
-                            .device_cache
-                            .fetch(device, |device| {
-                                self.auth
-                                    .authorize_as(
-                                        &self.application.metadata.name,
-                                        &self.device.metadata.name,
-                                        device,
-                                    )
-                                    .map_ok(|result| match result.outcome {
-                                        GatewayOutcome::Pass { r#as } => Some(r#as),
-                                        _ => None,
-                                    })
+            Ok(topic) => match topic.device {
+                Some(device) => self
+                    .device_cache
+                    .fetch(device, |device| {
+                        self.auth
+                            .authorize_as(
+                                &self.application.metadata.name,
+                                &self.device.metadata.name,
+                                device,
+                            )
+                            .map_ok(|result| match result.outcome {
+                                GatewayOutcome::Pass { r#as } => Some(r#as),
+                                _ => None,
                             })
-                            .await
-                            .map(|r| (topic.channel.to_string(), r))
-                    }
-                    None => {
-                        Ok((topic.channel.to_string(), self.device.clone()))
-                    }
-                }
-            }
+                    })
+                    .await
+                    .map(|r| (topic.channel.to_string(), r)),
+                None => Ok((topic.channel.to_string(), self.device.clone())),
+            },
             Err(_) => Err(PublishError::TopicNameInvalid),
         }
-
     }
 }
 
 #[async_trait(? Send)]
 impl<S> mqtt::Session for Session<S>
-    where
-        S: Sink,
+where
+    S: Sink,
 {
     #[instrument(level = "debug", skip(self), fields(self.id = ?self.id), err)]
     async fn publish(&self, publish: Publish<'_>) -> Result<(), PublishError> {
@@ -275,7 +271,7 @@ impl<S> mqtt::Session for Session<S>
                         CommandFilter::wildcard(self.id.app_id.clone(), self.id.device_id.clone()),
                         false,
                     )
-                        .await;
+                    .await;
                     sub.confirm(QoS::AtMostOnce);
                 }
                 ["command", "inbox", "", "#"] => {
@@ -284,7 +280,7 @@ impl<S> mqtt::Session for Session<S>
                         CommandFilter::device(self.id.app_id.clone(), self.id.device_id.clone()),
                         false,
                     )
-                        .await;
+                    .await;
                     sub.confirm(QoS::AtMostOnce);
                 }
                 ["command", "inbox", device, "#"] => {
@@ -297,7 +293,7 @@ impl<S> mqtt::Session for Session<S>
                         ),
                         true,
                     )
-                        .await;
+                    .await;
                     sub.confirm(QoS::AtMostOnce);
                 }
                 _ => {

--- a/mqtt-endpoint/src/service/session/mod.rs
+++ b/mqtt-endpoint/src/service/session/mod.rs
@@ -28,10 +28,42 @@ use std::{
 };
 use tracing::instrument;
 
+
+// TODO this is the section for the example Implementation of the Dialects
+struct HonoDialect;
+struct LongTopicDialect;
+
+struct ParseError;
+
+struct ParsedTopic<'a> {
+    channel: &'a str,
+    device: Option<&'a str>,
+}
+
+struct TopicHandler<D> {
+    dialect: D
+}
+
+trait Dialect {
+    fn handle(&self, path: &str) -> Result<ParsedTopic, ParseError>;
+}
+
+impl Dialect for TopicHandler<HonoDialect> {
+    fn handle(&self, path: &str) -> Result<ParsedTopic, ParseError> {
+        Ok(ParsedTopic { channel: path, device: Some(path) })
+    }
+}
+
+impl Dialect for TopicHandler<LongTopicDialect> {
+    fn handle(&self, path: &str) -> Result<ParsedTopic, ParseError> {
+        Ok(ParsedTopic { channel: path, device: None })
+    }
+}
+
 #[derive(Clone)]
 pub struct Session<S>
-where
-    S: Sink,
+    where
+        S: Sink,
 {
     sender: DownstreamSender<S>,
     application: registry::v1::Application,
@@ -45,8 +77,8 @@ where
 }
 
 impl<S> Session<S>
-where
-    S: Sink,
+    where
+        S: Sink,
 {
     pub fn new(
         config: &EndpointConfig,
@@ -99,7 +131,7 @@ where
                     self.sink.clone(),
                     force_device,
                 )
-                .await;
+                    .await;
                 entry.insert(subscription);
             }
         }
@@ -113,33 +145,64 @@ where
         let topic = publish.topic().path().split('/').collect::<Vec<_>>();
         log::debug!("Topic: {:?}", topic);
 
-        match topic.as_slice() {
-            [channel] => Ok((channel.to_string(), self.device.clone())),
-            [channel, as_device] => self
-                .device_cache
-                .fetch(as_device, |as_device| {
-                    self.auth
-                        .authorize_as(
-                            &self.application.metadata.name,
-                            &self.device.metadata.name,
-                            as_device,
-                        )
-                        .map_ok(|result| match result.outcome {
-                            GatewayOutcome::Pass { r#as } => Some(r#as),
-                            _ => None,
-                        })
-                })
-                .await
-                .map(|r| (channel.to_string(), r)),
-            _ => Err(PublishError::TopicNameInvalid),
+        // TODO this should be removed and is just there as an example
+        let handler = TopicHandler {dialect: HonoDialect};
+
+        match handler.handle(publish.topic().path()) {
+            Ok(topic) => {
+                match topic.device {
+                    Some(device) => {
+                        self
+                            .device_cache
+                            .fetch(device, |device| {
+                                self.auth
+                                    .authorize_as(
+                                        &self.application.metadata.name,
+                                        &self.device.metadata.name,
+                                        device,
+                                    )
+                                    .map_ok(|result| match result.outcome {
+                                        GatewayOutcome::Pass { r#as } => Some(r#as),
+                                        _ => None,
+                                    })
+                            })
+                            .await
+                            .map(|r| (topic.channel.to_string(), r))
+                    }
+                    None => {
+                        Ok((topic.channel.to_string(), self.device.clone()))
+                    }
+                }
+            }
+            Err(_) => Err(PublishError::TopicNameInvalid),
         }
+        // match topic.as_slice() {
+        //     [channel] => Ok((channel.to_string(), self.device.clone())),
+        //     [channel, as_device] => self
+        //         .device_cache
+        //         .fetch(as_device, |as_device| {
+        //             self.auth
+        //                 .authorize_as(
+        //                     &self.application.metadata.name,
+        //                     &self.device.metadata.name,
+        //                     as_device,
+        //                 )
+        //                 .map_ok(|result| match result.outcome {
+        //                     GatewayOutcome::Pass { r#as } => Some(r#as),
+        //                     _ => None,
+        //                 })
+        //         })
+        //         .await
+        //         .map(|r| (channel.to_string(), r)),
+        //     _ => Err(PublishError::TopicNameInvalid),
+        // }
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait(? Send)]
 impl<S> mqtt::Session for Session<S>
-where
-    S: Sink,
+    where
+        S: Sink,
 {
     #[instrument(level = "debug", skip(self), fields(self.id = ?self.id), err)]
     async fn publish(&self, publish: Publish<'_>) -> Result<(), PublishError> {
@@ -223,7 +286,7 @@ where
                         CommandFilter::wildcard(self.id.app_id.clone(), self.id.device_id.clone()),
                         false,
                     )
-                    .await;
+                        .await;
                     sub.confirm(QoS::AtMostOnce);
                 }
                 ["command", "inbox", "", "#"] => {
@@ -232,7 +295,7 @@ where
                         CommandFilter::device(self.id.app_id.clone(), self.id.device_id.clone()),
                         false,
                     )
-                    .await;
+                        .await;
                     sub.confirm(QoS::AtMostOnce);
                 }
                 ["command", "inbox", device, "#"] => {
@@ -245,7 +308,7 @@ where
                         ),
                         true,
                     )
-                    .await;
+                        .await;
                     sub.confirm(QoS::AtMostOnce);
                 }
                 _ => {


### PR DESCRIPTION
This pull request adds two different MQTT 3.1 topic name parsing strategies.
Currently only the "DrogueV1" is active and there is no way to switch it via configuration just now.

Closes #222.