### PR TITLE
fix(endpoints): Add missing UID for downstream events

### DIFF
--- a/coap-endpoint/src/downstream.rs
+++ b/coap-endpoint/src/downstream.rs
@@ -35,8 +35,8 @@ where
     ) -> Result<Option<CoapResponse>, CoapEndpointError> {
         let filter = CommandFilter::proxied_device(
             &publish.application.metadata.name,
-            &publish.sender_id,
-            &publish.device_id,
+            &publish.sender.name,
+            &publish.device.name,
         );
         match self.publish(publish, &req.message.payload).await {
             // ok, and accepted

--- a/coap-endpoint/src/telemetry.rs
+++ b/coap-endpoint/src/telemetry.rs
@@ -3,7 +3,7 @@ use coap_lite::{CoapOption, CoapRequest, CoapResponse};
 use drogue_cloud_endpoint_common::{
     command::Commands,
     error::EndpointError,
-    sender::{self, DownstreamSender},
+    sender::{self, DownstreamSender, ToPublishId},
     sink::Sink,
 };
 use drogue_cloud_service_api::auth::device::authn;
@@ -121,17 +121,17 @@ where
     // If we have an "as" parameter, we publish as another device.
     let (sender_id, device_id) = match r#as {
         // use the "as" information as device id
-        Some(r#as) => (device.metadata.name, r#as.metadata.name),
+        Some(r#as) => ((&device.metadata).to_id(), (&r#as.metadata).to_id()),
         // use the original device id
-        None => (device.metadata.name.clone(), device.metadata.name),
+        None => ((&device.metadata).to_id(), (&device.metadata).to_id()),
     };
 
     // Create Publish Object
     let publish = sender::Publish {
         channel,
         application: &application,
-        device_id,
-        sender_id,
+        device: device_id,
+        sender: sender_id,
         options: sender::PublishOptions {
             data_schema: opts.common.data_schema,
             topic: suffix,

--- a/http-endpoint/src/downstream.rs
+++ b/http-endpoint/src/downstream.rs
@@ -42,8 +42,8 @@ where
     {
         let filter = CommandFilter::proxied_device(
             &publish.application.metadata.name,
-            &publish.sender_id,
-            &publish.device_id,
+            &publish.sender.name,
+            &publish.device.name,
         );
         match self.publish(publish, body).await {
             // ok, and accepted

--- a/integration-common/src/commands/mod.rs
+++ b/integration-common/src/commands/mod.rs
@@ -3,7 +3,10 @@ mod sender;
 use drogue_client::{registry, Translator};
 use drogue_cloud_endpoint_common::{
     error::HttpEndpointError,
-    sender::{Publish, PublishOptions, PublishOutcome, Publisher, UpstreamSender},
+    sender::{
+        IntoPublishId, Publish, PublishOptions, PublishOutcome, Publisher, ToPublishId,
+        UpstreamSender,
+    },
     sink::Sink,
 };
 use drogue_cloud_service_api::webapp::HttpResponse;
@@ -77,8 +80,8 @@ where
                 Publish {
                     channel: opts.command.clone(),
                     application: &application,
-                    device_id: opts.device.clone(),
-                    sender_id: target,
+                    device: opts.device.to_id(),
+                    sender: target.into_id(),
                     options: PublishOptions {
                         content_type: opts.content_type.clone(),
                         ..Default::default()

--- a/mqtt-endpoint/src/service/session/mod.rs
+++ b/mqtt-endpoint/src/service/session/mod.rs
@@ -5,6 +5,7 @@ use crate::{auth::DeviceAuthenticator, config::EndpointConfig, CONNECTIONS_COUNT
 use async_trait::async_trait;
 use cache::DeviceCache;
 use drogue_client::registry;
+use drogue_cloud_endpoint_common::sender::ToPublishId;
 use drogue_cloud_endpoint_common::{
     command::{CommandFilter, Commands},
     sender::{
@@ -164,8 +165,8 @@ where
                 sender::Publish {
                     channel: channel.to_string(),
                     application: &self.application,
-                    device_id: device.metadata.name.clone(),
-                    sender_id: self.device.metadata.name.clone(),
+                    device: device.metadata.to_id(),
+                    sender: self.device.metadata.to_id(),
                     options: PublishOptions {
                         content_type,
                         ..Default::default()

--- a/service-api/src/id.rs
+++ b/service-api/src/id.rs
@@ -2,3 +2,7 @@ pub const EXT_INSTANCE: &str = "instance";
 pub const EXT_APPLICATION: &str = "application";
 pub const EXT_DEVICE: &str = "device";
 pub const EXT_SENDER: &str = "sender";
+
+pub const EXT_APPLICATION_UID: &str = "applicationuid";
+pub const EXT_DEVICE_UID: &str = "deviceuid";
+pub const EXT_SENDER_UID: &str = "senderuid";


### PR DESCRIPTION
According to our spec, downstream events should have the app/device
name, but also the UID. Currently the UID was missing, this change adds
it.

Closes: #226