### PR TITLE
Allow enchriching data during ingress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1739,7 +1739,7 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 [[package]]
 name = "drogue-client"
 version = "0.9.0-alpha.1"
-source = "git+https://github.com/drogue-iot/drogue-client?rev=6e37d2f8e7d4daec4735041dcb3ffb40a67eda32#6e37d2f8e7d4daec4735041dcb3ffb40a67eda32"
+source = "git+https://github.com/drogue-iot/drogue-client?rev=1df84bed4237aac130bbced776e8cf902f743a30#1df84bed4237aac130bbced776e8cf902f743a30"
 dependencies = [
  "async-std",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1739,7 +1739,7 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 [[package]]
 name = "drogue-client"
 version = "0.9.0-alpha.1"
-source = "git+https://github.com/drogue-iot/drogue-client?rev=a5c028dbc88d77552d553903d546ed14cbf80513#a5c028dbc88d77552d553903d546ed14cbf80513"
+source = "git+https://github.com/drogue-iot/drogue-client?rev=6e37d2f8e7d4daec4735041dcb3ffb40a67eda32#6e37d2f8e7d4daec4735041dcb3ffb40a67eda32"
 dependencies = [
  "async-std",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1739,7 +1739,7 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 [[package]]
 name = "drogue-client"
 version = "0.9.0-alpha.1"
-source = "git+https://github.com/drogue-iot/drogue-client?rev=32d29e670abf7a1c9ebb99d3cadda64bcf1748f6#32d29e670abf7a1c9ebb99d3cadda64bcf1748f6"
+source = "git+https://github.com/drogue-iot/drogue-client?rev=a5c028dbc88d77552d553903d546ed14cbf80513#a5c028dbc88d77552d553903d546ed14cbf80513"
 dependencies = [
  "async-std",
  "async-trait",
@@ -1748,6 +1748,7 @@ dependencies = [
  "chrono",
  "futures",
  "http",
+ "humantime-serde",
  "log",
  "openid",
  "opentelemetry",
@@ -2130,6 +2131,7 @@ dependencies = [
  "http",
  "lazy_static 1.4.0",
  "log",
+ "lru",
  "mime",
  "ntex",
  "openid",
@@ -3202,6 +3204,9 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash 0.7.6",
+]
 
 [[package]]
 name = "headers"
@@ -3823,6 +3828,15 @@ checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
  "value-bag",
+]
+
+[[package]]
+name = "lru"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "274353858935c992b13c0ca408752e2121da852d07dec7ce5f108c77dfa14d1f"
+dependencies = [
+ "hashbrown 0.11.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ testcontainers = { git = "https://github.com/testcontainers/testcontainers-rs", 
 #reqwest = { git = "https://github.com/ctron/reqwest", branch = "feature/basic_auth_wasm_1" }
 #drogue-ttn = { git = "https://github.com/drogue-iot/drogue-ttn", rev = "cf0338a344309815f0f05e0d7d76acb712445175" } # FIXME: awaiting release
 
-drogue-client = { git = "https://github.com/drogue-iot/drogue-client", rev = "32d29e670abf7a1c9ebb99d3cadda64bcf1748f6" } # FIXME: awaiting release
+drogue-client = { git = "https://github.com/drogue-iot/drogue-client", rev = "a5c028dbc88d77552d553903d546ed14cbf80513" } # FIXME: awaiting release
 #drogue-client = { path = "../drogue-client" }
 
 operator-framework = { git = "https://github.com/ctron/operator-framework", rev = "d4415ccbc03417942f38573a0e164143bae9a25e" } # FIXME: awaiting release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ testcontainers = { git = "https://github.com/testcontainers/testcontainers-rs", 
 #reqwest = { git = "https://github.com/ctron/reqwest", branch = "feature/basic_auth_wasm_1" }
 #drogue-ttn = { git = "https://github.com/drogue-iot/drogue-ttn", rev = "cf0338a344309815f0f05e0d7d76acb712445175" } # FIXME: awaiting release
 
-drogue-client = { git = "https://github.com/drogue-iot/drogue-client", rev = "6e37d2f8e7d4daec4735041dcb3ffb40a67eda32" } # FIXME: awaiting release
+drogue-client = { git = "https://github.com/drogue-iot/drogue-client", rev = "1df84bed4237aac130bbced776e8cf902f743a30" } # FIXME: awaiting release
 #drogue-client = { path = "../drogue-client" }
 
 operator-framework = { git = "https://github.com/ctron/operator-framework", rev = "d4415ccbc03417942f38573a0e164143bae9a25e" } # FIXME: awaiting release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ testcontainers = { git = "https://github.com/testcontainers/testcontainers-rs", 
 #reqwest = { git = "https://github.com/ctron/reqwest", branch = "feature/basic_auth_wasm_1" }
 #drogue-ttn = { git = "https://github.com/drogue-iot/drogue-ttn", rev = "cf0338a344309815f0f05e0d7d76acb712445175" } # FIXME: awaiting release
 
-drogue-client = { git = "https://github.com/drogue-iot/drogue-client", rev = "a5c028dbc88d77552d553903d546ed14cbf80513" } # FIXME: awaiting release
+drogue-client = { git = "https://github.com/drogue-iot/drogue-client", rev = "6e37d2f8e7d4daec4735041dcb3ffb40a67eda32" } # FIXME: awaiting release
 #drogue-client = { path = "../drogue-client" }
 
 operator-framework = { git = "https://github.com/ctron/operator-framework", rev = "d4415ccbc03417942f38573a0e164143bae9a25e" } # FIXME: awaiting release

--- a/coap-endpoint/src/lib.rs
+++ b/coap-endpoint/src/lib.rs
@@ -8,6 +8,7 @@ mod telemetry;
 use crate::{auth::DeviceAuthenticator, error::CoapEndpointError, response::Responder};
 use coap::Server;
 use coap_lite::{CoapOption, CoapRequest, CoapResponse};
+use drogue_cloud_endpoint_common::sender::ExternalClientPoolConfig;
 use drogue_cloud_endpoint_common::{
     auth::AuthConfig,
     command::{Commands, KafkaCommandSource, KafkaCommandSourceConfig},
@@ -56,6 +57,9 @@ pub struct Config {
 
     #[serde(default = "defaults::check_kafka_topic_ready")]
     pub check_kafka_topic_ready: bool,
+
+    #[serde(default)]
+    pub endpoint_pool: ExternalClientPoolConfig,
 }
 
 #[derive(Clone, Debug)]
@@ -230,6 +234,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
             config.check_kafka_topic_ready,
         )?,
         config.instance,
+        config.endpoint_pool,
     )?;
 
     let app = App {

--- a/command-endpoint/src/lib.rs
+++ b/command-endpoint/src/lib.rs
@@ -3,6 +3,7 @@ mod v1alpha1;
 use actix_cors::Cors;
 use actix_web::{get, middleware, web, App, HttpResponse, HttpServer, Responder};
 use drogue_client::openid::OpenIdTokenProvider;
+use drogue_cloud_endpoint_common::sender::ExternalClientPoolConfig;
 use drogue_cloud_endpoint_common::{sender::UpstreamSender, sink::KafkaSink};
 use drogue_cloud_service_api::webapp as actix_web;
 use drogue_cloud_service_api::{auth::user::authz::Permission, kafka::KafkaClientConfig};
@@ -48,6 +49,9 @@ pub struct Config {
 
     #[serde(default = "defaults::instance")]
     pub instance: String,
+
+    #[serde(default)]
+    pub endpoint_pool: ExternalClientPoolConfig,
 }
 
 #[derive(Debug)]
@@ -66,6 +70,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     let sender = UpstreamSender::new(
         config.instance,
         KafkaSink::from_config(config.command_kafka_sink, config.check_kafka_topic_ready)?,
+        config.endpoint_pool,
     )?;
 
     let max_json_payload_size = config.max_json_payload_size;

--- a/endpoint-common/Cargo.toml
+++ b/endpoint-common/Cargo.toml
@@ -39,6 +39,7 @@ tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 uuid = { version = "0.8", features = ["v4"] }
 x509-parser = "0.9"
+lru = "0.7"
 
 ntex = { version = "0.5", optional = true }
 tokio-openssl = { version = "0.6", optional = true }

--- a/endpoint-common/src/sender/process/external.rs
+++ b/endpoint-common/src/sender/process/external.rs
@@ -1,0 +1,183 @@
+use async_std::sync::Mutex;
+use drogue_client::registry::v1::{Authentication, ExternalEndpoint, TlsOptions};
+use drogue_cloud_service_common::reqwest::to_method;
+use http::{header::HeaderName, HeaderMap, HeaderValue, Method};
+use lru::LruCache;
+use reqwest::{Certificate, Url};
+use serde::Deserialize;
+use std::{sync::Arc, time::Duration};
+use thiserror::Error;
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Error)]
+pub enum ExternalError {
+    #[error("Invalid configuration: {0}")]
+    InvalidConfiguration(String),
+    #[error("Request error: {0}")]
+    Request(#[from] reqwest::Error),
+    #[error("Cloud event error: {0}")]
+    CloudEvent(#[from] cloudevents::message::Error),
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct ExternalClientPoolConfig {
+    pub capacity: usize,
+}
+
+impl Default for ExternalClientPoolConfig {
+    fn default() -> Self {
+        Self { capacity: 8 }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ExternalClientPool {
+    cache: Arc<Mutex<LruCache<Option<TlsOptions>, ExternalClient>>>,
+}
+
+impl Default for ExternalClientPool {
+    fn default() -> Self {
+        Self::new(Default::default())
+    }
+}
+
+impl ExternalClientPool {
+    pub fn new(config: ExternalClientPoolConfig) -> Self {
+        let cache = Arc::new(Mutex::new(LruCache::new(config.capacity)));
+        Self { cache }
+    }
+
+    pub async fn get(&self, endpoint: &ExternalEndpoint) -> Result<ExternalClient, ExternalError> {
+        let mut cache = self.cache.lock().await;
+        if let Some(client) = cache.get(&endpoint.tls) {
+            Ok(client.clone())
+        } else {
+            let client = ExternalClient::new(endpoint.tls.as_ref())?;
+            cache.put(endpoint.tls.clone(), client.clone());
+            Ok(client)
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ExternalClient {
+    client: reqwest::Client,
+}
+
+impl ExternalClient {
+    pub fn new(tls: Option<&TlsOptions>) -> Result<Self, reqwest::Error> {
+        let mut client = reqwest::Client::builder();
+
+        if let Some(tls) = tls {
+            if tls.insecure {
+                client = client
+                    .danger_accept_invalid_certs(true)
+                    .danger_accept_invalid_hostnames(true);
+            }
+            if let Some(cert) = &tls.certificate {
+                client = client
+                    .tls_built_in_root_certs(false)
+                    .add_root_certificate(Certificate::from_pem(cert.as_bytes())?);
+            }
+        }
+
+        Ok(Self {
+            client: client.build()?,
+        })
+    }
+
+    pub async fn process(
+        &self,
+        event: cloudevents::Event,
+        endpoint: &ExternalEndpoint,
+    ) -> Result<reqwest::Response, ExternalError> {
+        let method = to_method(endpoint.method.as_deref().unwrap_or(""))
+            .map_err(ExternalError::InvalidConfiguration)?
+            .unwrap_or(Method::POST);
+
+        let url = Url::parse(&endpoint.url)
+            .map_err(|err| ExternalError::InvalidConfiguration(format!("Invalid URL: {err}")))?;
+
+        // new request
+
+        let mut request = self.client.request(method, url);
+
+        // headers
+
+        let headers = endpoint.headers.len();
+        if headers > 0 {
+            let mut headers = HeaderMap::with_capacity(headers);
+            for entry in &endpoint.headers {
+                let name = HeaderName::try_from(&entry.name).map_err(|err| {
+                    ExternalError::InvalidConfiguration(format!("Invalid header name: {err}"))
+                })?;
+                headers.insert(
+                    name,
+                    HeaderValue::from_str(&entry.value).map_err(|err| {
+                        ExternalError::InvalidConfiguration(format!("Invalid header value: {err}"))
+                    })?,
+                );
+            }
+            request = request.headers(headers);
+        }
+
+        match &endpoint.auth {
+            Authentication::None => {}
+            Authentication::Basic { username, password } => {
+                request = request.basic_auth(username, password.as_ref());
+            }
+            Authentication::Bearer { token } => {
+                request = request.bearer_auth(token);
+            }
+        }
+
+        request = request.timeout(endpoint.timeout.unwrap_or(DEFAULT_TIMEOUT));
+
+        // cloud event mapping
+
+        request = cloudevents::binding::reqwest::event_to_request(event, request)?;
+
+        // execute
+
+        request.send().await.map_err(ExternalError::Request)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use drogue_client::registry::v1::TlsOptions;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_key() {
+        let key1a = None;
+        let key1b = None;
+        let key2a = Some(TlsOptions {
+            insecure: false,
+            certificate: None,
+        });
+        let key2b = Some(TlsOptions {
+            insecure: false,
+            certificate: None,
+        });
+        let key3 = Some(TlsOptions {
+            insecure: true,
+            certificate: None,
+        });
+
+        let mut map = HashMap::new();
+
+        map.insert(key1a.clone(), 100);
+        map.insert(key1b.clone(), 1); // should override
+        map.insert(key2a.clone(), 200);
+        map.insert(key2b.clone(), 2); // should override
+        map.insert(key3.clone(), 3);
+
+        assert_eq!(Some(1), map.get(&key1a).cloned());
+        assert_eq!(Some(1), map.get(&key1b).cloned());
+        assert_eq!(Some(2), map.get(&key2a).cloned());
+        assert_eq!(Some(2), map.get(&key2b).cloned());
+        assert_eq!(Some(3), map.get(&key3).cloned());
+    }
+}

--- a/endpoint-common/src/sender/process/mod.rs
+++ b/endpoint-common/src/sender/process/mod.rs
@@ -361,6 +361,29 @@ mod test {
         )
     }
 
+    #[tokio::test]
+    async fn test_parse_1() {
+        let spec = json!({
+          "rules": [
+            {
+              "when":
+                {
+                    "isChannel": "state"
+                },
+              "then": [
+                {
+                  "enrich": {
+                    "method": "POST",
+                    "url": "https://some-external-service/path/to"
+                  }
+                }
+              ]
+            }
+          ]
+        });
+        let _: PublishSpec = serde_json::from_value(spec).unwrap();
+    }
+
     async fn assert_process(spec: serde_json::Value, input: cloudevents::Event, expected: Outcome) {
         let spec: PublishSpec = serde_json::from_value(spec).unwrap();
         let processor = Processor::from(spec.rules);

--- a/http-endpoint/src/lib.rs
+++ b/http-endpoint/src/lib.rs
@@ -10,11 +10,10 @@ use actix_web::{
     App, HttpResponse, HttpServer, Responder,
 };
 use drogue_cloud_endpoint_common::{
-    auth::AuthConfig,
+    auth::{AuthConfig, DeviceAuthenticator},
     command::{Commands, KafkaCommandSource, KafkaCommandSourceConfig},
-};
-use drogue_cloud_endpoint_common::{
-    auth::DeviceAuthenticator, sender::DownstreamSender, sink::KafkaSink,
+    sender::{DownstreamSender, ExternalClientPoolConfig},
+    sink::KafkaSink,
 };
 use drogue_cloud_service_api::{
     kafka::KafkaClientConfig,
@@ -60,6 +59,9 @@ pub struct Config {
 
     #[serde(default)]
     pub workers: Option<usize>,
+
+    #[serde(default)]
+    pub endpoint_pool: ExternalClientPoolConfig,
 }
 
 #[get("/")]
@@ -76,6 +78,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
             config.check_kafka_topic_ready,
         )?,
         config.instance,
+        config.endpoint_pool,
     )?;
     let commands = Commands::new();
 

--- a/integration-common/src/commands/sender/default.rs
+++ b/integration-common/src/commands/sender/default.rs
@@ -10,7 +10,7 @@ impl Sender for DefaultSender {
     async fn send(
         &self,
         ctx: Context,
-        endpoint: registry::v1::ExternalEndpoint,
+        endpoint: registry::v1::ExternalCommandEndpoint,
         command: CommandOptions,
         payload: web::Bytes,
     ) -> Result<(), Error> {

--- a/integration-common/src/commands/sender/ttnv2.rs
+++ b/integration-common/src/commands/sender/ttnv2.rs
@@ -10,7 +10,7 @@ impl Sender for TtnV2Sender {
     async fn send(
         &self,
         ctx: Context,
-        endpoint: registry::v1::ExternalEndpoint,
+        endpoint: registry::v1::ExternalCommandEndpoint,
         command: CommandOptions,
         payload: web::Bytes,
     ) -> Result<(), Error> {

--- a/integration-common/src/commands/sender/ttnv3.rs
+++ b/integration-common/src/commands/sender/ttnv3.rs
@@ -10,7 +10,7 @@ impl Sender for TtnV3Sender {
     async fn send(
         &self,
         ctx: Context,
-        endpoint: registry::v1::ExternalEndpoint,
+        endpoint: registry::v1::ExternalCommandEndpoint,
         command: CommandOptions,
         payload: web::Bytes,
     ) -> Result<(), Error> {

--- a/mqtt-endpoint/src/config.rs
+++ b/mqtt-endpoint/src/config.rs
@@ -1,4 +1,6 @@
-use drogue_cloud_endpoint_common::{auth::AuthConfig, command::KafkaCommandSourceConfig};
+use drogue_cloud_endpoint_common::{
+    auth::AuthConfig, command::KafkaCommandSourceConfig, sender::ExternalClientPoolConfig,
+};
 use drogue_cloud_mqtt_common::server::{MqttServerOptions, TlsConfig};
 use drogue_cloud_service_api::kafka::KafkaClientConfig;
 use drogue_cloud_service_common::{defaults, health::HealthServerConfig};
@@ -64,6 +66,9 @@ pub struct Config {
 
     #[serde(default = "defaults::check_kafka_topic_ready")]
     pub check_kafka_topic_ready: bool,
+
+    #[serde(default)]
+    pub endpoint_pool: ExternalClientPoolConfig,
 }
 
 impl TlsConfig for Config {

--- a/mqtt-endpoint/src/lib.rs
+++ b/mqtt-endpoint/src/lib.rs
@@ -36,6 +36,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
                 config.check_kafka_topic_ready,
             )?,
             config.instance.clone(),
+            config.endpoint_pool.clone(),
         )?,
 
         authenticator: DeviceAuthenticator(

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -819,6 +819,7 @@ fn main() {
                         kafka_command_config: kafka,
                         check_kafka_topic_ready: false,
                         bind_addr: server.http.clone().into(),
+                        endpoint_pool: Default::default(),
                     };
 
                     handles.push(Box::pin(drogue_cloud_http_endpoint::run(config)));
@@ -894,6 +895,7 @@ fn main() {
                         kafka_downstream_config: kafka.clone(),
                         kafka_command_config: kafka,
                         check_kafka_topic_ready: false,
+                        endpoint_pool: Default::default(),
                     };
 
                     handles.push(Box::pin(drogue_cloud_mqtt_endpoint::run(config.clone())));
@@ -939,6 +941,7 @@ fn main() {
                         user_auth: None,
                         instance: "drogue".to_string(),
                         command_kafka_sink: kafka,
+                        endpoint_pool: Default::default(),
                     };
 
                     handles.push(Box::pin(drogue_cloud_mqtt_integration::run(config.clone())));
@@ -982,6 +985,7 @@ fn main() {
                     kafka_downstream_config: kafka.clone(),
                     kafka_command_config: kafka,
                     check_kafka_topic_ready: false,
+                    endpoint_pool: Default::default(),
                 };
 
                 runner.block_on(async move {

--- a/service-common/src/app.rs
+++ b/service-common/src/app.rs
@@ -1,5 +1,3 @@
-use opentelemetry::sdk::trace::Sampler;
-use std::env;
 #[macro_export]
 macro_rules! app {
     () => {
@@ -33,8 +31,9 @@ Drogue IoT {} - {} {} ({})
     }};
 }
 
+#[cfg(feature = "jaeger")]
 fn enable_tracing() -> bool {
-    env::var("ENABLE_TRACING")
+    std::env::var("ENABLE_TRACING")
         .ok()
         .map(|s| s.eq_ignore_ascii_case("true"))
         .unwrap_or_default()
@@ -55,8 +54,9 @@ pub fn init_tracing(name: &str) {
     let pipeline = tracing::opentelemetry_jaeger::new_pipeline()
         .with_service_name(name)
         .with_trace_config(
-            tracing::opentelemetry::sdk::trace::Config::default()
-                .with_sampler(Sampler::ParentBased(Box::new(tracing::sampler()))),
+            tracing::opentelemetry::sdk::trace::Config::default().with_sampler(
+                opentelemetry::sdk::trace::Sampler::ParentBased(Box::new(tracing::sampler())),
+            ),
         );
 
     println!("Using Jaeger tracing.");
@@ -74,10 +74,12 @@ pub fn init_tracing(name: &str) {
 }
 
 #[cfg(not(feature = "jaeger"))]
+#[allow(unused)]
 fn init_tracing(_: &str) {
     init_no_tracing()
 }
 
+#[allow(unused)]
 fn init_no_tracing() {
     env_logger::init();
     log::info!("Tracing is not enabled");

--- a/service-common/src/reqwest.rs
+++ b/service-common/src/reqwest.rs
@@ -1,8 +1,26 @@
 use reqwest::Certificate;
-use std::path::PathBuf;
-use std::{fs::File, io::Read, path::Path};
+use std::{
+    fs::File,
+    io::Read,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 
 const SERVICE_CA_CERT: &str = "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt";
+
+/// Convert the name to an HTTP method.
+///
+/// If the name is empty, [`None`] is returned. If the method is invalid, and error will be returned.
+pub fn to_method(name: &str) -> Result<Option<reqwest::Method>, String> {
+    if name.is_empty() {
+        Ok(None)
+    } else {
+        match reqwest::Method::from_str(name) {
+            Ok(m) => Ok(Some(m)),
+            Err(_) => Err(format!("Invalid HTTP method: {}", name)),
+        }
+    }
+}
 
 fn add_cert<P: AsRef<Path>>(
     mut client: reqwest::ClientBuilder,

--- a/ttn-operator/src/controller/app.rs
+++ b/ttn-operator/src/controller/app.rs
@@ -324,7 +324,7 @@ impl<'a> ApplicationReconciler<'a> {
 
         gateway.set_section(registry::v1::DeviceSpecCommands {
             commands: vec![registry::v1::Command::External(
-                registry::v1::ExternalEndpoint {
+                registry::v1::ExternalCommandEndpoint {
                     r#type: Some("ttnv3".to_string()),
                     url: downlink_url.to_string(),
                     headers,


### PR DESCRIPTION
When data comes in, it is now possible to send data to an external endpoint, in order to enrich data. Alternatively data can be validated too, without modifying it.