### PR TITLE
[fix] authZ : add a Not found outcome when app don't exist

### DIFF
--- a/service-common/src/actix_auth/authorization/mod.rs
+++ b/service-common/src/actix_auth/authorization/mod.rs
@@ -56,9 +56,10 @@ impl AuthZ {
 
                 match response.outcome {
                     authz::Outcome::Allow => Ok(()),
-                    authz::Outcome::Deny => {
-                        Err(ServiceError::InvalidRequest(String::from("Unauthorized")))
-                    }
+                    authz::Outcome::Deny => Err(ServiceError::NotFound(
+                        String::from("Application"),
+                        application.to_string(),
+                    )),
                 }
             }
             // No auth client


### PR DESCRIPTION
when authorizing access to applications that doesn't exist, the user_auth service was replying `Outcome::Deny` without more details. So service would not know what to report to user. 
See #220 