### PR TITLE
Allow metrics to be registered twice

### DIFF
--- a/endpoint-common/src/sender/mod.rs
+++ b/endpoint-common/src/sender/mod.rs
@@ -18,7 +18,7 @@ use drogue_cloud_service_api::{
     webapp::HttpResponse, EXT_APPLICATION_UID, EXT_DEVICE_UID, EXT_INSTANCE, EXT_SENDER,
     EXT_SENDER_UID,
 };
-use drogue_cloud_service_common::{Id, IdInjector};
+use drogue_cloud_service_common::{metrics, Id, IdInjector};
 use lazy_static::lazy_static;
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use process::Processor;
@@ -238,9 +238,7 @@ where
         instance: String,
         config: ExternalClientPoolConfig,
     ) -> anyhow::Result<Self> {
-        prometheus::default_registry()
-            .register(Box::new(DOWNSTREAM_EVENTS_COUNTER.clone()))
-            .unwrap();
+        metrics::register(Box::new(DOWNSTREAM_EVENTS_COUNTER.clone()))?;
         Ok(Self {
             sink,
             instance,

--- a/mqtt-endpoint/src/lib.rs
+++ b/mqtt-endpoint/src/lib.rs
@@ -11,7 +11,7 @@ use drogue_cloud_endpoint_common::{
     sink::KafkaSink,
 };
 use drogue_cloud_mqtt_common::server::build;
-use drogue_cloud_service_common::health::HealthServer;
+use drogue_cloud_service_common::{health::HealthServer, metrics};
 use futures::TryFutureExt;
 use lazy_static::lazy_static;
 use prometheus::{IntGauge, Opts};
@@ -60,9 +60,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
 
     // run
     if let Some(health) = config.health {
-        prometheus::default_registry()
-            .register(Box::new(CONNECTIONS_COUNTER.clone()))
-            .unwrap();
+        metrics::register(Box::new(CONNECTIONS_COUNTER.clone()))?;
         // health server
         let health = HealthServer::new(
             health,

--- a/mqtt-integration/src/lib.rs
+++ b/mqtt-integration/src/lib.rs
@@ -12,6 +12,7 @@ use drogue_cloud_service_common::{
     client::{RegistryConfig, UserAuthClient, UserAuthClientConfig},
     defaults,
     health::{HealthServer, HealthServerConfig},
+    metrics,
     openid::AuthenticatorConfig,
     reqwest::ClientFactory,
 };
@@ -155,9 +156,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     // run
 
     if let Some(health) = config.health {
-        prometheus::default_registry()
-            .register(Box::new(CONNECTIONS_COUNTER.clone()))
-            .unwrap();
+        metrics::register(Box::new(CONNECTIONS_COUNTER.clone()))?;
         // health server
         let health =
             HealthServer::new(health, vec![], Some(prometheus::default_registry().clone()));

--- a/service-common/src/lib.rs
+++ b/service-common/src/lib.rs
@@ -10,6 +10,7 @@ pub mod health;
 pub mod id;
 pub mod keycloak;
 pub mod kube;
+pub mod metrics;
 pub mod openid;
 pub mod reqwest;
 pub mod tracing;

--- a/service-common/src/metrics.rs
+++ b/service-common/src/metrics.rs
@@ -1,0 +1,13 @@
+use prometheus::core::Collector;
+use std::boxed::Box;
+
+pub fn register(metric: Box<dyn Collector>) -> anyhow::Result<()> {
+    match prometheus::default_registry().register(metric) {
+        Ok(_) => Ok(()),
+        Err(prometheus::Error::AlreadyReg) => {
+            log::debug!("Metric already registered");
+            Ok(())
+        }
+        Err(e) => Err(e.into()),
+    }
+}

--- a/websocket-integration/src/lib.rs
+++ b/websocket-integration/src/lib.rs
@@ -14,6 +14,7 @@ use drogue_cloud_service_common::{
     client::{RegistryConfig, UserAuthClient, UserAuthClientConfig},
     defaults,
     health::{HealthServer, HealthServerConfig},
+    metrics,
     openid::AuthenticatorConfig,
 };
 use futures::TryFutureExt;
@@ -114,9 +115,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
 
     // run
     if let Some(health) = config.health {
-        prometheus::default_registry()
-            .register(Box::new(CONNECTIONS_COUNTER.clone()))
-            .unwrap();
+        metrics::register(Box::new(CONNECTIONS_COUNTER.clone()))?;
         let health =
             HealthServer::new(health, vec![], Some(prometheus::default_registry().clone()));
         futures::try_join!(health.run(), main.err_into())?;


### PR DESCRIPTION
This fixes drogue-cloud-server which caused one metrics to be registered
multiple times. Add a wrapper function that ignores the AlreadyReg error
and prints a warning to the log.