### PR TITLE
[feat] console - add pagination

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -251,3 +251,4 @@ trunk serve
 #### Running with a cloud backend
 
 You can also run the frontend with a backend in the cloud (or local cluster, e.g. minikube).
+To do so, you can create a `console-frontend/dev/endpoints/backend.local.json` file and populate it with the API and SSO urls of your drogue instance.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,58 +72,11 @@ dependencies = [
 [[package]]
 name = "actix-http"
 version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5885cb81a0d4d0d322864bea1bb6c2a8144626b4fdc625d4c51eba197e7797a"
-dependencies = [
- "actix-codec 0.3.0",
- "actix-connect",
- "actix-rt 1.1.1",
- "actix-service 1.0.6",
- "actix-threadpool",
- "actix-utils 2.0.0",
- "base64 0.13.0",
- "bitflags",
- "brotli",
- "bytes 0.5.6",
- "cookie 0.14.4",
- "copyless",
- "derive_more",
- "either",
- "encoding_rs",
- "flate2",
- "futures-channel",
- "futures-core",
- "futures-util",
- "fxhash",
- "h2 0.2.7",
- "http",
- "httparse",
- "indexmap",
- "itoa 0.4.8",
- "language-tags 0.2.2",
- "lazy_static 1.4.0",
- "log",
- "mime",
- "percent-encoding",
- "pin-project 1.0.10",
- "rand 0.7.3",
- "regex",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sha-1 0.9.8",
- "slab",
- "time 0.2.27",
-]
-
-[[package]]
-name = "actix-http"
-version = "3.0.4"
 source = "git+https://github.com/lulf/actix-web?rev=936839319e18da302209f56ef1288ce29c956858#936839319e18da302209f56ef1288ce29c956858"
 dependencies = [
- "actix-codec 0.5.0",
- "actix-rt 2.6.0",
- "actix-service 2.0.2",
+ "actix-codec",
+ "actix-rt",
+ "actix-service",
  "actix-tls",
  "actix-utils",
  "ahash 0.7.6",
@@ -253,9 +206,9 @@ name = "actix-web"
 version = "4.0.1"
 source = "git+https://github.com/lulf/actix-web?rev=936839319e18da302209f56ef1288ce29c956858#936839319e18da302209f56ef1288ce29c956858"
 dependencies = [
- "actix-codec 0.5.0",
- "actix-http 3.0.4",
- "actix-macros 0.2.3",
+ "actix-codec",
+ "actix-http",
+ "actix-macros",
  "actix-router",
  "actix-rt",
  "actix-server",
@@ -295,8 +248,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31efe7896f3933ce03dd4710be560254272334bb321a18fd8ff62b1a557d9d19"
 dependencies = [
  "actix",
- "actix-codec 0.5.0",
- "actix-http 3.0.4",
+ "actix-codec",
+ "actix-http",
  "actix-web",
  "bytes 1.1.0",
  "bytestring",
@@ -350,7 +303,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "503ff1136a085f39fc9fd96818a5e9c7ab58ccd36682f3cfc32a001d01cc3a50"
 dependencies = [
- "actix-http 3.0.4",
+ "actix-http",
  "actix-web",
  "futures-util",
  "opentelemetry",
@@ -875,7 +828,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c036aa864420e0e684386a979f1847e8e170d3bfa8375b0675132bc8ab46b4"
 dependencies = [
- "actix-http 3.0.4",
+ "actix-http",
  "actix-web",
  "async-trait",
  "base64 0.12.3",
@@ -1685,8 +1638,8 @@ name = "drogue-cloud-device-management-service"
 version = "0.10.0"
 dependencies = [
  "actix-cors",
- "actix-http 3.0.4",
- "actix-rt 2.6.0",
+ "actix-http",
+ "actix-rt",
  "anyhow",
  "async-trait",
  "base64 0.13.0",

--- a/console-frontend/Cargo.lock
+++ b/console-frontend/Cargo.lock
@@ -1781,7 +1781,7 @@ checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
 [[package]]
 name = "patternfly-yew"
 version = "0.2.0"
-source = "git+https://github.com/ctron/patternfly-yew?rev=9d47434bcde791d21691bdd491f0b7ebd7df53fe#9d47434bcde791d21691bdd491f0b7ebd7df53fe"
+source = "git+https://github.com/ctron/patternfly-yew?rev=4d94074a35b35f7f237effc68bead6dc3b79567a#4d94074a35b35f7f237effc68bead6dc3b79567a"
 dependencies = [
  "chrono",
  "gloo-events",

--- a/console-frontend/Cargo.lock
+++ b/console-frontend/Cargo.lock
@@ -1781,7 +1781,7 @@ checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
 [[package]]
 name = "patternfly-yew"
 version = "0.2.0"
-source = "git+https://github.com/ctron/patternfly-yew?rev=57829945179d823f754314d870290edc3de9701d#57829945179d823f754314d870290edc3de9701d"
+source = "git+https://github.com/ctron/patternfly-yew?rev=e930eb2cda924e27acebb4e8de9125d5c2651026#e930eb2cda924e27acebb4e8de9125d5c2651026"
 dependencies = [
  "chrono",
  "gloo-events",

--- a/console-frontend/Cargo.lock
+++ b/console-frontend/Cargo.lock
@@ -1781,7 +1781,7 @@ checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
 [[package]]
 name = "patternfly-yew"
 version = "0.2.0"
-source = "git+https://github.com/ctron/patternfly-yew?rev=e930eb2cda924e27acebb4e8de9125d5c2651026#e930eb2cda924e27acebb4e8de9125d5c2651026"
+source = "git+https://github.com/ctron/patternfly-yew?rev=9d47434bcde791d21691bdd491f0b7ebd7df53fe#9d47434bcde791d21691bdd491f0b7ebd7df53fe"
 dependencies = [
  "chrono",
  "gloo-events",

--- a/console-frontend/Cargo.toml
+++ b/console-frontend/Cargo.toml
@@ -91,7 +91,7 @@ opt-level = 's'
 lto = true
 
 [patch.crates-io]
-patternfly-yew = { git = "https://github.com/ctron/patternfly-yew", rev = "e930eb2cda924e27acebb4e8de9125d5c2651026" } # FIXME: awaiting release
+patternfly-yew = { git = "https://github.com/ctron/patternfly-yew", rev = "9d47434bcde791d21691bdd491f0b7ebd7df53fe" } # FIXME: awaiting release
 #patternfly-yew = { path = "../../patternfly-yew" }
 
 drogue-client = { git = "https://github.com/drogue-iot/drogue-client", rev = "788e3ba00b675b15e3adcd83836f6e2b8f678bc3" } # FIXME: awaiting release

--- a/console-frontend/Cargo.toml
+++ b/console-frontend/Cargo.toml
@@ -91,7 +91,7 @@ opt-level = 's'
 lto = true
 
 [patch.crates-io]
-patternfly-yew = { git = "https://github.com/ctron/patternfly-yew", rev = "57829945179d823f754314d870290edc3de9701d" } # FIXME: awaiting release
+patternfly-yew = { git = "https://github.com/ctron/patternfly-yew", rev = "e930eb2cda924e27acebb4e8de9125d5c2651026" } # FIXME: awaiting release
 #patternfly-yew = { path = "../../patternfly-yew" }
 
 drogue-client = { git = "https://github.com/drogue-iot/drogue-client", rev = "788e3ba00b675b15e3adcd83836f6e2b8f678bc3" } # FIXME: awaiting release

--- a/console-frontend/Cargo.toml
+++ b/console-frontend/Cargo.toml
@@ -91,7 +91,7 @@ opt-level = 's'
 lto = true
 
 [patch.crates-io]
-patternfly-yew = { git = "https://github.com/ctron/patternfly-yew", rev = "9d47434bcde791d21691bdd491f0b7ebd7df53fe" } # FIXME: awaiting release
+patternfly-yew = { git = "https://github.com/ctron/patternfly-yew", rev = "4d94074a35b35f7f237effc68bead6dc3b79567a" } # FIXME: awaiting release
 #patternfly-yew = { path = "../../patternfly-yew" }
 
 drogue-client = { git = "https://github.com/drogue-iot/drogue-client", rev = "788e3ba00b675b15e3adcd83836f6e2b8f678bc3" } # FIXME: awaiting release

--- a/console-frontend/src/backend/mod.rs
+++ b/console-frontend/src/backend/mod.rs
@@ -85,6 +85,7 @@ impl BackendInformation {
         &self,
         method: http::Method,
         path: S,
+        query: Vec<(&str, &str)>,
         payload: IN,
         headers: Vec<(String, String)>,
         handler: H,
@@ -98,6 +99,10 @@ impl BackendInformation {
 
         for (k, v) in headers {
             request = request.header(k.into(), v.into());
+        }
+
+        for (k, v) in query {
+            request = request.query(k.into(), v.into());
         }
 
         request = request
@@ -118,6 +123,7 @@ impl AuthenticatedBackend {
         &self,
         method: http::Method,
         path: S,
+        query: Vec<(&str, &str)>,
         payload: IN,
         headers: Vec<(String, String)>,
         handler: H,
@@ -127,13 +133,14 @@ impl AuthenticatedBackend {
         IN: RequestPayload,
         H: RequestHandler<anyhow::Result<Response>>,
     {
-        self.request_with(method, path, payload, headers, handler)
+        self.request_with(method, path, query, payload, headers, handler)
     }
 
     pub fn request_with<S, IN, H>(
         &self,
         method: http::Method,
         path: S,
+        query: Vec<(&str, &str)>,
         payload: IN,
         mut headers: Vec<(String, String)>,
         handler: H,
@@ -147,7 +154,7 @@ impl AuthenticatedBackend {
         headers.push(("Authorization".into(), bearer));
 
         self.backend
-            .unauth_request_with(method, path, payload, headers, handler)
+            .unauth_request_with(method, path, query, payload, headers, handler)
     }
 }
 

--- a/console-frontend/src/components/about.rs
+++ b/console-frontend/src/components/about.rs
@@ -75,6 +75,7 @@ impl AboutModal {
         Ok(ctx.props().backend.request(
             Method::GET,
             "/.well-known/drogue-version",
+            vec![],
             Nothing,
             vec![],
             ctx.callback_api::<Json<DrogueVersion>, _>(|response| match response {

--- a/console-frontend/src/examples/mod.rs
+++ b/console-frontend/src/examples/mod.rs
@@ -138,6 +138,7 @@ impl ExamplePage {
         Ok(ctx.props().backend.request(
             Method::GET,
             "/api/console/v1alpha1/info",
+            vec![],
             Nothing,
             vec![],
             ctx.callback_api::<Json<Endpoints>, _>(|response| match response {

--- a/console-frontend/src/pages/access_tokens.rs
+++ b/console-frontend/src/pages/access_tokens.rs
@@ -178,6 +178,7 @@ impl AccessTokens {
         Ok(ctx.props().backend.request(
             Method::GET,
             "/api/tokens/v1alpha1",
+            vec![],
             Nothing,
             vec![],
             ctx.callback_api::<Json<Vec<AccessToken>>, _>(move |response| match response {
@@ -204,6 +205,7 @@ impl AccessTokens {
         Ok(ctx.props().backend.request(
             Method::DELETE,
             format!("/api/tokens/v1alpha1/{}", token.prefix),
+            vec![],
             Nothing,
             vec![],
             ctx.callback_api::<(), _>(move |response| match response {
@@ -217,6 +219,7 @@ impl AccessTokens {
         Ok(ctx.props().backend.request(
             Method::POST,
             "/api/tokens/v1alpha1",
+            vec![],
             Nothing,
             vec![],
             ctx.callback_api::<Json<AccessTokenCreated>, _>(move |response| match response {

--- a/console-frontend/src/pages/apps/create.rs
+++ b/console-frontend/src/pages/apps/create.rs
@@ -118,6 +118,7 @@ impl CreateDialog {
         Ok(ctx.props().backend.request(
             Method::POST,
             "/api/registry/v1alpha1/apps",
+            vec![],
             Json(payload),
             vec![],
             ctx.callback_api::<(), _>(move |response| match response {

--- a/console-frontend/src/pages/apps/details/admin.rs
+++ b/console-frontend/src/pages/apps/details/admin.rs
@@ -304,6 +304,7 @@ impl Admin {
                 "/api/admin/v1alpha1/apps/{}/members",
                 url_encode(&ctx.props().name)
             ),
+            vec![],
             Nothing,
             vec![],
             ctx.callback_api::<Json<Members>, _>(move |response| match response {
@@ -328,6 +329,7 @@ impl Admin {
                     "/api/admin/v1alpha1/apps/{}/members",
                     url_encode(&ctx.props().name)
                 ),
+                vec![],
                 Json(members),
                 vec![],
                 ctx.callback_api::<(), _>(move |response| match response {
@@ -369,6 +371,7 @@ impl Admin {
                 "/api/admin/v1alpha1/apps/{}/transfer-ownership",
                 url_encode(&ctx.props().name)
             ),
+            vec![],
             Json(payload),
             vec![],
             ctx.callback_api::<(), _>(move |response| match response {
@@ -401,6 +404,7 @@ impl Admin {
                 "/api/admin/v1alpha1/apps/{}/transfer-ownership",
                 url_encode(&ctx.props().name)
             ),
+            vec![],
             Nothing,
             vec![],
             ctx.callback_api::<(), _>(|response| match response {
@@ -417,6 +421,7 @@ impl Admin {
                 "/api/admin/v1alpha1/apps/{}/transfer-ownership",
                 url_encode(&ctx.props().name)
             ),
+            vec![],
             Nothing,
             vec![],
             ctx.callback_api::<Option<Json<TransferOwnership>>, _>(move |response| {

--- a/console-frontend/src/pages/apps/details/mod.rs
+++ b/console-frontend/src/pages/apps/details/mod.rs
@@ -147,6 +147,7 @@ impl Details {
                     "/api/registry/v1alpha1/apps/{}",
                     url_encode(&ctx.props().name)
                 ),
+                vec![],
                 Nothing,
                 vec![],
                 ctx.callback_api::<Json<Application>, _>(move |response| match response {
@@ -160,6 +161,7 @@ impl Details {
                     "/api/admin/v1alpha1/apps/{}/members",
                     url_encode(&ctx.props().name)
                 ),
+                vec![],
                 Nothing,
                 vec![],
                 ctx.callback_api::<(), _>(move |response| match response {
@@ -181,6 +183,7 @@ impl Details {
                 "/api/registry/v1alpha1/apps/{}",
                 url_encode(&ctx.props().name)
             ),
+            vec![],
             Json(&app),
             vec![],
             ctx.callback_api::<(), _>(move |response| match response {

--- a/console-frontend/src/pages/apps/index.rs
+++ b/console-frontend/src/pages/apps/index.rs
@@ -164,6 +164,7 @@ impl Index {
         Ok(ctx.props().backend.request(
             Method::GET,
             "/api/registry/v1alpha1/apps",
+            vec![],
             Nothing,
             vec![],
             ctx.callback_api::<Json<Vec<Application>>, _>(move |response| match response {
@@ -194,6 +195,7 @@ impl Index {
         Ok(ctx.props().backend.request(
             Method::DELETE,
             format!("/api/registry/v1alpha1/apps/{}", url_encode(name)),
+            vec![],
             Nothing,
             vec![],
             ctx.callback_api::<(), _>(move |response| match response {

--- a/console-frontend/src/pages/apps/index.rs
+++ b/console-frontend/src/pages/apps/index.rs
@@ -67,7 +67,7 @@ pub enum Msg {
     TriggerModal,
 
     Navigate(patternfly_yew::Navigation),
-    SetLimit(i32),
+    SetLimit(u32),
 }
 
 pub struct Index {

--- a/console-frontend/src/pages/apps/ownership.rs
+++ b/console-frontend/src/pages/apps/ownership.rs
@@ -141,6 +141,7 @@ impl Ownership {
                 "/api/admin/v1alpha1/apps/{}/transfer-ownership",
                 url_encode(&ctx.props().name)
             ),
+            vec![],
             Nothing,
             vec![],
             ctx.callback_api::<(), _>(move |response| match response {
@@ -158,6 +159,7 @@ impl Ownership {
                 "/api/admin/v1alpha1/apps/{}/accept-ownership",
                 url_encode(&ctx.props().name)
             ),
+            vec![],
             Nothing,
             vec![],
             ctx.callback_api::<(), _>(move |response| match response {
@@ -174,6 +176,7 @@ impl Ownership {
                 "/api/admin/v1alpha1/apps/{}/transfer-ownership",
                 url_encode(&ctx.props().name)
             ),
+            vec![],
             Nothing,
             vec![],
             ctx.callback_api::<(), _>(move |response| match response {

--- a/console-frontend/src/pages/devices/create.rs
+++ b/console-frontend/src/pages/devices/create.rs
@@ -125,6 +125,7 @@ impl CreateDialog {
         Ok(ctx.props().backend.request(
             Method::POST,
             format!("/api/registry/v1alpha1/apps/{}/devices", url_encode(app)),
+            vec![],
             Json(&payload),
             vec![],
             ctx.callback_api::<(), _>(move |response| match response {

--- a/console-frontend/src/pages/devices/details.rs
+++ b/console-frontend/src/pages/devices/details.rs
@@ -111,6 +111,7 @@ impl Details {
                 url_encode(&ctx.props().app),
                 url_encode(&ctx.props().name)
             ),
+            vec![],
             Nothing,
             vec![],
             ctx.callback_api::<Json<Device>, _>(move |response| match response {
@@ -128,6 +129,7 @@ impl Details {
                 url_encode(&ctx.props().app),
                 url_encode(&ctx.props().name)
             ),
+            vec![],
             Json(app),
             vec![],
             ctx.callback_api::<(), _>(move |response| match response {

--- a/console-frontend/src/pages/devices/index.rs
+++ b/console-frontend/src/pages/devices/index.rs
@@ -61,7 +61,7 @@ pub enum Msg {
     LoadApps,
     Load,
     Navigate(patternfly_yew::Navigation),
-    SetLimit(i32),
+    SetLimit(u32),
     SetData(Vec<DeviceEntry>),
     SetApps(Vec<String>),
     SetApp(String),

--- a/console-frontend/src/pages/devices/index.rs
+++ b/console-frontend/src/pages/devices/index.rs
@@ -120,6 +120,7 @@ impl Component for Index {
                     Navigation::Next => self.paging_options.next(),
                     //fixme the registry must returns the total number of device for that
                     Navigation::Last => self.paging_options.next(),
+                    Navigation::Page(page) => self.paging_options.page(page),
                 };
                 ctx.link().send_message(Msg::Load);
             }
@@ -243,8 +244,8 @@ impl Component for Index {
             }} else { html!{
                 <PageSection>
                 <Toolbar>
-                    <ToolbarGroup>
-                        <ToolbarItem modifiers={[ToolbarElementModifier::Right.all()]}>
+                    <ToolbarGroup modifiers={[ToolbarElementModifier::Right.all()]}>
+                        <ToolbarItem>
                             <Pagination
                                 offset= {self.paging_options.offset}
                                 selected_choice={self.paging_options.limit}

--- a/console-frontend/src/utils/mod.rs
+++ b/console-frontend/src/utils/mod.rs
@@ -1,8 +1,10 @@
+mod paging;
 mod shell;
 mod toast;
 mod validators;
 mod yaml;
 
+pub use paging::*;
 pub use shell::*;
 pub use toast::*;
 pub use validators::*;

--- a/console-frontend/src/utils/paging.rs
+++ b/console-frontend/src/utils/paging.rs
@@ -1,0 +1,44 @@
+#[derive(Clone, Copy)]
+pub struct PagingOptions {
+    pub offset: i32,
+    pub limit: i32,
+}
+
+impl Default for PagingOptions {
+    fn default() -> Self {
+        PagingOptions {
+            offset: 0,
+            limit: 20,
+        }
+    }
+}
+
+impl PagingOptions {
+    pub fn previous(self) -> Self {
+        PagingOptions {
+            offset: self.offset - self.limit,
+            limit: self.limit,
+        }
+    }
+
+    pub fn next(self) -> Self {
+        PagingOptions {
+            offset: self.offset + self.limit,
+            limit: self.limit,
+        }
+    }
+
+    pub fn first(self) -> Self {
+        PagingOptions {
+            offset: 0,
+            limit: self.limit,
+        }
+    }
+
+    pub fn last(self, max: i32) -> Self {
+        PagingOptions {
+            offset: max - self.limit,
+            limit: self.limit,
+        }
+    }
+}

--- a/console-frontend/src/utils/paging.rs
+++ b/console-frontend/src/utils/paging.rs
@@ -41,4 +41,11 @@ impl PagingOptions {
             limit: self.limit,
         }
     }
+
+    pub fn page(self, page: i32) -> Self {
+        PagingOptions {
+            offset: self.limit * page - self.limit,
+            limit: self.limit,
+        }
+    }
 }

--- a/console-frontend/src/utils/paging.rs
+++ b/console-frontend/src/utils/paging.rs
@@ -1,7 +1,7 @@
 #[derive(Clone, Copy)]
 pub struct PagingOptions {
-    pub offset: i32,
-    pub limit: i32,
+    pub offset: u32,
+    pub limit: u32,
 }
 
 impl Default for PagingOptions {
@@ -36,14 +36,14 @@ impl PagingOptions {
     }
     #[allow(dead_code)]
     // this is not used right now as drogue API don't return the total number of entries
-    pub fn last(self, max: i32) -> Self {
+    pub fn last(self, max: u32) -> Self {
         PagingOptions {
             offset: max - self.limit,
             limit: self.limit,
         }
     }
 
-    pub fn page(self, page: i32) -> Self {
+    pub fn page(self, page: u32) -> Self {
         PagingOptions {
             offset: self.limit * page - self.limit,
             limit: self.limit,

--- a/console-frontend/src/utils/paging.rs
+++ b/console-frontend/src/utils/paging.rs
@@ -34,7 +34,8 @@ impl PagingOptions {
             limit: self.limit,
         }
     }
-
+    #[allow(dead_code)]
+    // this is not used right now as drogue API don't return the total number of entries
     pub fn last(self, max: i32) -> Self {
         PagingOptions {
             offset: max - self.limit,

--- a/console-frontend/src/utils/paging.rs
+++ b/console-frontend/src/utils/paging.rs
@@ -16,7 +16,7 @@ impl Default for PagingOptions {
 impl PagingOptions {
     pub fn previous(self) -> Self {
         PagingOptions {
-            offset: self.offset - self.limit,
+            offset: self.offset.checked_sub(self.limit).unwrap_or(0),
             limit: self.limit,
         }
     }
@@ -38,14 +38,14 @@ impl PagingOptions {
     // this is not used right now as drogue API don't return the total number of entries
     pub fn last(self, max: u32) -> Self {
         PagingOptions {
-            offset: max - self.limit,
+            offset: max.checked_sub(self.limit).unwrap_or(0),
             limit: self.limit,
         }
     }
 
     pub fn page(self, page: u32) -> Self {
         PagingOptions {
-            offset: self.limit * page - self.limit,
+            offset: (self.limit * page).checked_sub(self.limit).unwrap_or(0),
             limit: self.limit,
         }
     }


### PR DESCRIPTION
The "last page" button is acting as a "next" button, as the registry does not
sends back the total number of devices when limiting, so we cannot calculate the total number of pages. This seems to be the recommended behaviour in patternfly examples.

Allow to pass query options to the wasm request builder


![image](https://user-images.githubusercontent.com/12406409/168844355-cec77f39-8cbd-4c9f-93a1-17251e61fe4a.png)
![image](https://user-images.githubusercontent.com/12406409/168844260-d6004df0-d6d0-407f-a157-7d4779931793.png)

