### PR TITLE
[fix] Console - unlock buttons on YAML after an error occured

### DIFF
--- a/console-frontend/src/pages/apps/details/mod.rs
+++ b/console-frontend/src/pages/apps/details/mod.rs
@@ -97,6 +97,7 @@ impl Component for Details {
             }
             Msg::Error(msg) => {
                 msg.toast();
+                self.fetch_task = None;
             }
             Msg::SetAdmin(is_admin) => {
                 self.fetch_role = None;

--- a/console-frontend/src/pages/devices/details.rs
+++ b/console-frontend/src/pages/devices/details.rs
@@ -77,6 +77,7 @@ impl Component for Details {
             }
             Msg::Error(msg) => {
                 msg.toast();
+                self.fetch_task = None;
             }
         }
         true


### PR DESCRIPTION
Fixes #195 by simply allowing the buttons to work again even after an error