### PR TITLE
Update xref links for common-configuration.adoc

### DIFF
--- a/docs/modules/user-guide/pages/integration-knative.adoc
+++ b/docs/modules/user-guide/pages/integration-knative.adoc
@@ -17,7 +17,7 @@ spec:
     endpoint: # <1>
       url: https://my-knative-endpoint
 ----
-<1> External endpoint definition as described in xref:common.adoc#defining_external_endpoints[Defining external endpoints].
+<1> External endpoint definition as described in xref:common-configuration.adoc#defining_external_endpoints[Defining external endpoints].
 
 This will create a publisher, which will start sending new events as they come in.
 

--- a/docs/modules/user-guide/pages/management-rules.adoc
+++ b/docs/modules/user-guide/pages/management-rules.adoc
@@ -210,7 +210,7 @@ then:
       type: cloudEvent # <3>
       mode: binary # or structured <4>
 ----
-<1> Endpoint configuration as described in xref:common.adoc#defining_external_endpoints[External endpoints]
+<1> Endpoint configuration as described in xref:common-configuration.adoc#defining_external_endpoints[External endpoints]
 <2> Parameters for the outgoing request. Defaults to binary encoded cloud event.
 <3> Selects the type of the encoding
 <4> The cloud events mode: `binary` or `structured`
@@ -233,7 +233,7 @@ then:
     response: # <5>
       type: cloudEvent # <6>
 ----
-<1> Endpoint configuration as described in xref:common.adoc#defining_external_endpoints[External endpoints]
+<1> Endpoint configuration as described in xref:common-configuration.adoc#defining_external_endpoints[External endpoints]
 <2> Parameters for the outgoing request. Defaults to binary encoded cloud event.
 <3> Selects the type of the encoding
 <4> The cloud events mode: `binary` or `structured`


### PR DESCRIPTION
This commit updates the xref links for common.adoc. These were updated
in Commit 090bd950581950bf61a83d70469895de15a8ea2e ("docs: add more common information, and integrations").

Currently these are creating errors when running the GitHub Publish
action: https://github.com/drogue-iot/book.drogue.io/actions