### PR TITLE
Add a publisher Role allowing to send commands to apps 

### DIFF
--- a/command-endpoint/src/lib.rs
+++ b/command-endpoint/src/lib.rs
@@ -99,7 +99,7 @@ pub async fn configurator(
                     web::scope("/api/command/v1alpha1/apps/{application}/devices/{deviceId}")
                         .wrap(AuthZ {
                             client: user_auth.clone(),
-                            permission: Permission::Write,
+                            permission: Permission::Publish,
                             app_param: "application".to_string(),
                         })
                         .wrap(AuthN {

--- a/console-frontend/Cargo.lock
+++ b/console-frontend/Cargo.lock
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "drogue-cloud-console-common"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "drogue-cloud-service-api",
  "serde",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "drogue-cloud-console-frontend"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -475,14 +475,14 @@ dependencies = [
 
 [[package]]
 name = "drogue-cloud-macros"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "quote",
 ]
 
 [[package]]
 name = "drogue-cloud-service-api"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "base64 0.13.0",

--- a/console-frontend/src/pages/apps/details/admin.rs
+++ b/console-frontend/src/pages/apps/details/admin.rs
@@ -227,6 +227,7 @@ impl Component for Admin {
                                                 placeholder="Select user role"
                                                 variant={SelectVariant::Single(ctx.link().callback(Msg::NewMemberRole))}>
                                             <SelectOption<Role> value={Role::Reader} description="Read-only access" />
+                                            <SelectOption<Role> value={Role::Publisher} description="Read and publish access" />
                                             <SelectOption<Role> value={Role::Manager} description="Read-write access" />
                                             <SelectOption<Role> value={Role::Admin} description="Administrative access" />
                                         </Select<Role>>

--- a/database-common/src/auth.rs
+++ b/database-common/src/auth.rs
@@ -64,6 +64,10 @@ pub fn authorize(
                         Role::Admin | Role::Manager => Outcome::Allow,
                         _ => Outcome::Deny,
                     },
+                    Permission::Publish => match member.role {
+                        Role::Admin | Role::Manager | Role::Publisher => Outcome::Allow,
+                        _ => Outcome::Deny,
+                    },
                     Permission::Read => Outcome::Allow,
                 }
             } else {
@@ -170,6 +174,7 @@ mod test {
                 Permission::Owner => Outcome::Allow,
                 Permission::Admin => Outcome::Allow,
                 Permission::Write => Outcome::Allow,
+                Permission::Publish => Outcome::Allow,
                 Permission::Read => Outcome::Allow
             ]
         )
@@ -184,6 +189,7 @@ mod test {
                 Permission::Owner => Outcome::Allow,
                 Permission::Admin => Outcome::Allow,
                 Permission::Write => Outcome::Allow,
+                Permission::Publish => Outcome::Allow,
                 Permission::Read => Outcome::Allow
             ]
         )
@@ -198,6 +204,7 @@ mod test {
                 Permission::Owner => Outcome::Deny,
                 Permission::Admin => Outcome::Allow,
                 Permission::Write => Outcome::Allow,
+                Permission::Publish => Outcome::Allow,
                 Permission::Read => Outcome::Allow
             ]
         )
@@ -212,6 +219,22 @@ mod test {
                 Permission::Owner => Outcome::Deny,
                 Permission::Admin => Outcome::Deny,
                 Permission::Write => Outcome::Allow,
+                Permission::Publish => Outcome::Allow,
+                Permission::Read => Outcome::Allow
+            ]
+        )
+    }
+
+    #[test]
+    fn test_auth_resource_publisher() {
+        test_auth!(
+            resource!("foo", ["bar" => Role::Publisher]),
+            user("bar", &[]),
+            [
+                Permission::Owner => Outcome::Deny,
+                Permission::Admin => Outcome::Deny,
+                Permission::Write => Outcome::Deny,
+                Permission::Publish => Outcome::Allow,
                 Permission::Read => Outcome::Allow
             ]
         )
@@ -226,6 +249,7 @@ mod test {
                 Permission::Owner => Outcome::Deny,
                 Permission::Admin => Outcome::Deny,
                 Permission::Write => Outcome::Deny,
+                Permission::Publish => Outcome::Deny,
                 Permission::Read => Outcome::Allow
             ]
         )
@@ -240,6 +264,7 @@ mod test {
                 Permission::Owner => Outcome::Deny,
                 Permission::Admin => Outcome::Deny,
                 Permission::Write => Outcome::Deny,
+                Permission::Publish => Outcome::Deny,
                 Permission::Read => Outcome::Allow
             ]
         )
@@ -254,6 +279,7 @@ mod test {
                 Permission::Owner => Outcome::Deny,
                 Permission::Admin => Outcome::Deny,
                 Permission::Write => Outcome::Deny,
+                Permission::Publish => Outcome::Deny,
                 Permission::Read => Outcome::Deny
             ]
         )

--- a/docs/modules/user-guide/pages/management-app-members.adoc
+++ b/docs/modules/user-guide/pages/management-app-members.adoc
@@ -7,21 +7,23 @@ By default, an application have only an owner and no users to it's member list.
 == Members roles
 
 - Reader : This is the most basic level: read only access.
+- Publisher : Allows to subscribe to events and sends commands.
 - Manager: allows read and write access to the application. This include the reader role as well.
 - Administrator: This role allows to manage the members of the application, deleting the application, plus the above roles.
 
 |===
-|Actions |Reader |Manager | Administrator
+|Actions | Reader | Publisher | Manager | Administrator
 
-| read devices details                | ✔️ | ✔️ | ✔️
-| Consume application events stream   | ✔️ | ✔️ | ✔️
-| read application details            | ✔️ | ✔️ | ✔️
-| edit application details            | ❌ | ✔️ | ✔️
-| create and edit devices             | ❌ | ✔️ | ✔️
-| delete devices                      | ❌ | ✔️ | ✔️
-| Edit application details            | ❌ | ✔️ | ✔️
-| Delete application                  | ❌ | ❌ | ✔️
-| Edit application members            | ❌ | ❌ | ✔️
+| read devices details                | ✔️ | ✔️ | ✔️ | ✔️
+| consume application events stream   | ✔️ | ✔️ | ✔️ | ✔️
+| read application details            | ✔️ | ✔️ | ✔️ | ✔️
+| send commands to devices            | ❌️ | ✔️ | ✔️ | ✔️
+| edit application details            | ❌ | ❌️ | ✔️ | ✔️
+| create and edit devices             | ❌ | ❌️ | ✔️ | ✔️
+| delete devices                      | ❌ | ❌️ | ✔️ | ✔️
+| edit application details            | ❌ | ❌️ | ✔️ | ✔️
+| delete application                  | ❌ | ❌ | ❌️ | ✔️
+| edit application members            | ❌ | ❌ | ❌️ | ✔️
 
 |===
 

--- a/mqtt-integration/src/service/session.rs
+++ b/mqtt-integration/src/service/session.rs
@@ -269,7 +269,7 @@ impl mqtt::Session for Session {
             );
 
             if let Some(user_auth) = &self.user_auth {
-                self.authorize(app.to_string(), user_auth, Permission::Write)
+                self.authorize(app.to_string(), user_auth, Permission::Publish)
                     .await
                     .map_err(|_| PublishError::NotAuthorized)?;
             }

--- a/service-api/src/admin/mod.rs
+++ b/service-api/src/admin/mod.rs
@@ -30,6 +30,8 @@ pub enum Role {
     Admin,
     /// Allow reading and writing, but not changing members.
     Manager,
+    /// Allow reading and publishing commands.
+    Publisher,
     /// Allow reading only.
     Reader,
 }
@@ -39,6 +41,7 @@ impl Display for Role {
         match self {
             Self::Admin => write!(f, "Administrator"),
             Self::Manager => write!(f, "Manager"),
+            Self::Publisher => write!(f, "Publisher"),
             Self::Reader => write!(f, "Reader"),
         }
     }

--- a/service-api/src/auth/user/authz.rs
+++ b/service-api/src/auth/user/authz.rs
@@ -7,6 +7,7 @@ pub enum Permission {
     Owner,
     Admin,
     Write,
+    Publish,
     Read,
 }
 

--- a/user-auth-service/tests/members.rs
+++ b/user-auth-service/tests/members.rs
@@ -33,6 +33,7 @@ async fn test_auth_member_admin() {
     test_member!("app-member1", "bar-admin", [], Permission::Owner => "deny");
     test_member!("app-member1", "bar-admin", [], Permission::Admin => "allow");
     test_member!("app-member1", "bar-admin", [], Permission::Write => "allow");
+    test_member!("app-member1", "bar-admin", [], Permission::Publish => "allow");
     test_member!("app-member1", "bar-admin", [], Permission::Read => "allow");
 }
 
@@ -42,7 +43,18 @@ async fn test_auth_member_manager() {
     test_member!("app-member1", "bar-manager", [], Permission::Owner => "deny");
     test_member!("app-member1", "bar-manager", [], Permission::Admin => "deny");
     test_member!("app-member1", "bar-manager", [], Permission::Write => "allow");
+    test_member!("app-member1", "bar-manager", [], Permission::Publish => "allow");
     test_member!("app-member1", "bar-manager", [], Permission::Read => "allow");
+}
+
+#[actix_rt::test]
+#[serial]
+async fn test_auth_member_publisher() {
+    test_member!("app-member1", "bar-publisher", [], Permission::Owner => "deny");
+    test_member!("app-member1", "bar-publisher", [], Permission::Admin => "deny");
+    test_member!("app-member1", "bar-publisher", [], Permission::Write => "deny");
+    test_member!("app-member1", "bar-publisher", [], Permission::Publish => "allow");
+    test_member!("app-member1", "bar-publisher", [], Permission::Read => "allow");
 }
 
 #[actix_rt::test]
@@ -51,6 +63,7 @@ async fn test_auth_member_reader() {
     test_member!("app-member1", "bar-reader", [], Permission::Owner => "deny");
     test_member!("app-member1", "bar-reader", [], Permission::Admin => "deny");
     test_member!("app-member1", "bar-reader", [], Permission::Write => "deny");
+    test_member!("app-member1", "bar-reader", [], Permission::Publish => "deny");
     test_member!("app-member1", "bar-reader", [], Permission::Read => "allow");
 }
 
@@ -60,6 +73,7 @@ async fn test_auth_member_anon() {
     test_member!("app-member1", "", [], Permission::Owner => "deny");
     test_member!("app-member1", "", [], Permission::Admin => "deny");
     test_member!("app-member1", "", [], Permission::Write => "deny");
+    test_member!("app-member1", "", [], Permission::Publish => "deny");
     test_member!("app-member1", "", [], Permission::Read => "allow");
 }
 
@@ -69,5 +83,6 @@ async fn test_auth_member_anon_2() {
     test_member!("app-member1", Permission::Owner => "deny");
     test_member!("app-member1", Permission::Admin => "deny");
     test_member!("app-member1", Permission::Write => "deny");
+    test_member!("app-member1", Permission::Publish => "deny");
     test_member!("app-member1", Permission::Read => "allow");
 }

--- a/user-auth-service/tests/sql/20-members/up.sql
+++ b/user-auth-service/tests/sql/20-members/up.sql
@@ -24,6 +24,7 @@ INSERT INTO APPLICATIONS (
         "bar-admin": { "role": "admin" },
         "bar-manager": { "role": "manager" },
         "bar-reader": { "role": "reader" },
+        "bar-publisher": { "role": "publisher" },
         "": { "role": "reader" }
      }'::JSONB,
     '{}'::JSONB


### PR DESCRIPTION
but not modify the resources

I am thinking it's worth adding a another role :  "subscriber" : where you would only be able to subscribe to stream events and not read devices and applications details. 

Also, Maybe limit the "publisher" role to no be allowed to read as well ?