### PR TITLE
feat : console - add a delete button for apps

### DIFF
--- a/console-frontend/Cargo.lock
+++ b/console-frontend/Cargo.lock
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "drogue-cloud-console-common"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "drogue-cloud-service-api",
  "serde",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "drogue-cloud-console-frontend"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -475,14 +475,14 @@ dependencies = [
 
 [[package]]
 name = "drogue-cloud-macros"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "quote",
 ]
 
 [[package]]
 name = "drogue-cloud-service-api"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "base64 0.13.0",

--- a/console-frontend/src/pages/apps/details/delete.rs
+++ b/console-frontend/src/pages/apps/details/delete.rs
@@ -1,0 +1,114 @@
+use crate::error::error;
+use crate::error::{ErrorNotification, ErrorNotifier};
+use crate::pages::apps::{AppRoute, Pages};
+use crate::utils::{success, url_encode};
+use http::{Method, StatusCode};
+use patternfly_yew::*;
+use yew::prelude::*;
+use yew_router::{agent::RouteRequest, prelude::*};
+
+use crate::backend::{
+    ApiResponse, AuthenticatedBackend, JsonHandlerScopeExt, Nothing, RequestHandle,
+};
+
+#[derive(Clone, PartialEq, Properties)]
+pub struct Props {
+    pub backend: AuthenticatedBackend,
+    pub on_close: Callback<()>,
+    pub name: String,
+}
+
+pub enum Msg {
+    Success,
+    Error(ErrorNotification),
+    Delete,
+    Cancel,
+}
+
+pub struct DeleteConfirmation {
+    fetch_task: Option<RequestHandle>,
+}
+
+impl Component for DeleteConfirmation {
+    type Message = Msg;
+    type Properties = Props;
+
+    fn create(_: &Context<Self>) -> Self {
+        Self { fetch_task: None }
+    }
+
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
+        match msg {
+            Msg::Error(msg) => {
+                BackdropDispatcher::default().close();
+                msg.toast();
+            }
+            Msg::Delete => match self.delete(ctx) {
+                Ok(task) => self.fetch_task = Some(task),
+                Err(err) => error("Failed to Delete", err),
+            },
+            Msg::Success => {
+                ctx.props().on_close.emit(());
+                BackdropDispatcher::default().close();
+                success("Application deleted");
+                RouteAgentDispatcher::<()>::new().send(RouteRequest::ChangeRoute(Route::from(
+                    AppRoute::Applications(Pages::Index),
+                )))
+            }
+            Msg::Cancel => {
+                ctx.props().on_close.emit(());
+                BackdropDispatcher::default().close();
+            }
+        };
+        true
+    }
+
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        html! (
+            <Bullseye plain=true>
+                <Modal
+                    title={format!("Delete application {} ?", ctx.props().name)}
+                    description={"This cannot be undone."}
+                    variant={ModalVariant::Small}
+                    footer={html!(
+                        <>
+                            <Button
+                                label={"Delete"}
+                                variant={Variant::Danger}
+                                onclick={ctx.link().callback(|_|Msg::Delete)}
+                            />
+                            <Button
+                                label={"Cancel"}
+                                variant={Variant::Link}
+                                onclick={ctx.link().callback(|_|Msg::Cancel)}
+                            />
+                        </>
+                    )}
+                >
+                </Modal>
+            </Bullseye>
+        )
+    }
+}
+
+impl DeleteConfirmation {
+    fn delete(&self, ctx: &Context<Self>) -> Result<RequestHandle, anyhow::Error> {
+        Ok(ctx.props().backend.request(
+            Method::DELETE,
+            format!(
+                "/api/registry/v1alpha1/apps/{}",
+                url_encode(&ctx.props().name)
+            ),
+            vec![],
+            Nothing,
+            vec![],
+            ctx.callback_api::<(), _>(move |response| match response {
+                ApiResponse::Success(_, StatusCode::NO_CONTENT) => Msg::Success,
+                ApiResponse::Success(_, code) => {
+                    Msg::Error(format!("Unknown message code: {}", code).notify("Failed to delete"))
+                }
+                ApiResponse::Failure(err) => Msg::Error(err.notify("Failed to delete")),
+            }),
+        )?)
+    }
+}

--- a/console-frontend/src/pages/apps/details/mod.rs
+++ b/console-frontend/src/pages/apps/details/mod.rs
@@ -20,13 +20,14 @@ use crate::{
 };
 use drogue_client::registry::v1::Application;
 use drogue_cloud_console_common::EndpointInformation;
-use http::Method;
+use http::{Method, StatusCode};
 use monaco::{api::*, sys::editor::BuiltinTheme, yew::CodeEditor};
 use patternfly_yew::*;
 use std::{ops::Deref, rc::Rc};
 use yew::context::ContextHandle;
 use yew::prelude::*;
 use yew_oauth2::prelude::*;
+use yew_router::{agent::RouteRequest, prelude::*};
 
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct Props {
@@ -45,6 +46,8 @@ pub enum Msg {
     Error(ErrorNotification),
     SaveEditor,
     SetAdmin(bool),
+    Delete,
+    DeletionComplete,
 }
 
 pub struct Details {
@@ -116,6 +119,15 @@ impl Component for Details {
                 self.fetch_role = None;
                 self.is_admin = is_admin;
             }
+            Msg::Delete => match self.delete(ctx) {
+                    Ok(task) => {
+                        self.fetch_task = Some(task);
+                    },
+                    Err(err) => error("Failed to delete", err),
+            }
+            Msg::DeletionComplete => RouteAgentDispatcher::<()>::new().send(
+                RouteRequest::ChangeRoute(Route::from(AppRoute::Applications(Pages::Index))),
+            ),
         }
         true
     }
@@ -125,8 +137,19 @@ impl Component for Details {
             <>
                 <PageSection variant={PageSectionVariant::Light} limit_width=true>
                     <Content>
-                        <Title>{ctx.props().name.clone()}</Title>
-                    </Content>
+                        <Flex>
+                            <FlexItem>
+                                <Title>{ctx.props().name.clone()}</Title>
+                            </FlexItem>
+                            <FlexItem modifiers={[FlexModifier::Align(Alignement::Right).all()]}>
+                                <Button
+                                        label="Delete"
+                                        variant={Variant::DangerSecondary}
+                                        onclick={ctx.link().callback(|_|Msg::Delete)}
+                                />
+                                    </FlexItem>
+                                </Flex>
+                     </Content>
                 </PageSection>
             if let Some(app) = &self.content {
                 { self.render_content(ctx, app) }
@@ -189,6 +212,23 @@ impl Details {
             ctx.callback_api::<(), _>(move |response| match response {
                 ApiResponse::Success(..) => Msg::Load,
                 ApiResponse::Failure(err) => Msg::Error(err.notify("Failed to update")),
+            }),
+        )?)
+    }
+
+    fn delete(&self, ctx: &Context<Self>) -> Result<RequestHandle, anyhow::Error> {
+        Ok(ctx.props().backend.request(
+            Method::DELETE,
+            format!("/api/registry/v1alpha1/apps/{}", url_encode(&ctx.props().name)),
+            vec![],
+            Nothing,
+            vec![],
+            ctx.callback_api::<(), _>(move |response| match response {
+                ApiResponse::Success(_, StatusCode::NO_CONTENT) => Msg::DeletionComplete,
+                ApiResponse::Success(_, code) => {
+                    Msg::Error(format!("Unknown message code: {}", code).notify("Failed to delete"))
+                }
+                ApiResponse::Failure(err) => Msg::Error(err.notify("Failed to delete")),
             }),
         )?)
     }

--- a/console-frontend/src/pages/apps/details/mod.rs
+++ b/console-frontend/src/pages/apps/details/mod.rs
@@ -120,11 +120,11 @@ impl Component for Details {
                 self.is_admin = is_admin;
             }
             Msg::Delete => match self.delete(ctx) {
-                    Ok(task) => {
-                        self.fetch_task = Some(task);
-                    },
-                    Err(err) => error("Failed to delete", err),
-            }
+                Ok(task) => {
+                    self.fetch_task = Some(task);
+                }
+                Err(err) => error("Failed to delete", err),
+            },
             Msg::DeletionComplete => RouteAgentDispatcher::<()>::new().send(
                 RouteRequest::ChangeRoute(Route::from(AppRoute::Applications(Pages::Index))),
             ),
@@ -219,7 +219,10 @@ impl Details {
     fn delete(&self, ctx: &Context<Self>) -> Result<RequestHandle, anyhow::Error> {
         Ok(ctx.props().backend.request(
             Method::DELETE,
-            format!("/api/registry/v1alpha1/apps/{}", url_encode(&ctx.props().name)),
+            format!(
+                "/api/registry/v1alpha1/apps/{}",
+                url_encode(&ctx.props().name)
+            ),
             vec![],
             Nothing,
             vec![],

--- a/console-frontend/src/pages/devices/delete.rs
+++ b/console-frontend/src/pages/devices/delete.rs
@@ -1,0 +1,120 @@
+use crate::error::error;
+use crate::error::{ErrorNotification, ErrorNotifier};
+use crate::pages::devices::Pages;
+use crate::utils::{success, url_encode};
+use http::{Method, StatusCode};
+use patternfly_yew::*;
+use yew::prelude::*;
+use yew_router::{agent::RouteRequest, prelude::*};
+
+use crate::backend::{
+    ApiResponse, AuthenticatedBackend, JsonHandlerScopeExt, Nothing, RequestHandle,
+};
+use crate::console::AppRoute;
+use crate::pages::apps::ApplicationContext;
+
+#[derive(Clone, PartialEq, Properties)]
+pub struct Props {
+    pub backend: AuthenticatedBackend,
+    pub on_close: Callback<()>,
+    pub name: String,
+    pub app_name: String,
+}
+
+pub enum Msg {
+    Success,
+    Error(ErrorNotification),
+    Delete,
+    Cancel,
+}
+
+pub struct DeleteConfirmation {
+    fetch_task: Option<RequestHandle>,
+}
+
+impl Component for DeleteConfirmation {
+    type Message = Msg;
+    type Properties = Props;
+
+    fn create(_: &Context<Self>) -> Self {
+        Self { fetch_task: None }
+    }
+
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
+        match msg {
+            Msg::Error(msg) => {
+                BackdropDispatcher::default().close();
+                msg.toast();
+            }
+            Msg::Delete => match self.delete(ctx) {
+                Ok(task) => self.fetch_task = Some(task),
+                Err(err) => error("Failed to Delete", err),
+            },
+            Msg::Success => {
+                ctx.props().on_close.emit(());
+                BackdropDispatcher::default().close();
+                success("Device deleted");
+                RouteAgentDispatcher::<()>::new().send(RouteRequest::ChangeRoute(Route::from(
+                    AppRoute::Devices(Pages::Index {
+                        app: ApplicationContext::Single(ctx.props().app_name.clone()),
+                    }),
+                )))
+            }
+            Msg::Cancel => {
+                ctx.props().on_close.emit(());
+                BackdropDispatcher::default().close();
+            }
+        };
+        true
+    }
+
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        html! (
+            <Bullseye plain=true>
+                <Modal
+                    title={format!("Delete device {} ?", ctx.props().name)}
+                    description={"This cannot be undone."}
+                    variant={ModalVariant::Small}
+                    footer={html!(
+                        <>
+                            <Button
+                                label={"Delete"}
+                                variant={Variant::Danger}
+                                onclick={ctx.link().callback(|_|Msg::Delete)}
+                            />
+                            <Button
+                                label={"Cancel"}
+                                variant={Variant::Link}
+                                onclick={ctx.link().callback(|_|Msg::Cancel)}
+                            />
+                        </>
+                    )}
+                >
+                </Modal>
+            </Bullseye>
+        )
+    }
+}
+
+impl DeleteConfirmation {
+    fn delete(&self, ctx: &Context<Self>) -> Result<RequestHandle, anyhow::Error> {
+        Ok(ctx.props().backend.request(
+            Method::DELETE,
+            format!(
+                "/api/registry/v1alpha1/apps/{}/devices/{}",
+                url_encode(&ctx.props().app_name),
+                url_encode(&ctx.props().name)
+            ),
+            vec![],
+            Nothing,
+            vec![],
+            ctx.callback_api::<(), _>(move |response| match response {
+                ApiResponse::Success(_, StatusCode::NO_CONTENT) => Msg::Success,
+                ApiResponse::Success(_, code) => {
+                    Msg::Error(format!("Unknown message code: {}", code).notify("Failed to delete"))
+                }
+                ApiResponse::Failure(err) => Msg::Error(err.notify("Failed to delete")),
+            }),
+        )?)
+    }
+}

--- a/console-frontend/src/pages/devices/mod.rs
+++ b/console-frontend/src/pages/devices/mod.rs
@@ -1,4 +1,5 @@
 mod create;
+mod delete;
 mod details;
 mod index;
 


### PR DESCRIPTION
On the overview page for a an app, add a delete button

![image](https://user-images.githubusercontent.com/12406409/180444643-897efb42-2772-4136-a316-01c6543fcb1c.png)

currently, this simply delete the app/device and redirects you to the app list page. 

 confirmation modal : 
 
![image](https://user-images.githubusercontent.com/12406409/180474187-0376a6db-c68d-4077-b12c-8b3d330da228.png)
