### PR TITLE
[server] update to clap v3 and other improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,13 +888,34 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "ansi_term",
+ "bitflags",
+ "textwrap 0.11.0",
+ "unicode-width",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44bbe24bbd31a185bc2c4f7c2abe80bea13a20d57ee4e55be70ac512bdc76417"
+dependencies = [
  "atty",
  "bitflags",
- "strsim 0.8.0",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
+ "strsim",
+ "termcolor",
+ "textwrap 0.15.0",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -1061,7 +1082,7 @@ checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
 dependencies = [
  "atty",
  "cast",
- "clap",
+ "clap 2.34.0",
  "criterion-plot",
  "csv",
  "itertools",
@@ -1206,7 +1227,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim",
  "syn",
 ]
 
@@ -2220,7 +2241,7 @@ dependencies = [
  "actix-files",
  "actix-rt",
  "anyhow",
- "clap",
+ "clap 3.2.15",
  "deadpool",
  "deadpool-postgres",
  "diesel",
@@ -4167,6 +4188,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
+
+[[package]]
 name = "owning_ref"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5308,12 +5335,6 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -5386,6 +5407,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -5925,12 +5952,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 actix-files = "0.6"
 actix-rt = "2.2.0"
 anyhow = "1"
-clap = "2.33.3"
+clap = { version = "3.2.15", features = ["cargo", "env"] }
 deadpool = "0.9"
 deadpool-postgres = { version = "0.10", features = ["serde", "rt_tokio_1"] }
 diesel = { version = "1.4.8", features = ["postgres"] }

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -67,7 +67,7 @@ pub struct Drogue {
 }
 
 impl ServerConfig {
-    pub fn new(matches: &ArgMatches<'_>) -> ServerConfig {
+    pub fn new(matches: &ArgMatches) -> ServerConfig {
         let iface = matches
             .value_of("bind-address")
             .unwrap_or("localhost")


### PR DESCRIPTION
add a couple of missing args and fixes #310

So instead of crashing on an unwrap now clap will display an error : 
```
target/debug/drogue-cloud-server run --enable-all  --enable-console-frontend 
error: The following required arguments were not provided:
    --ui-dist <PATH>

USAGE:
    drogue-cloud-server run --ui-dist <PATH> --enable-all --enable-console-frontend
```
I still think that --enable console-frontend can be merged with --ui-dist but I don't want to break too much things