### PR TITLE
Add a clone button and menu entry for devices. Fixes #247

### DIFF
--- a/console-frontend/src/pages/devices/clone.rs
+++ b/console-frontend/src/pages/devices/clone.rs
@@ -1,0 +1,134 @@
+use crate::{
+    backend::{ApiResponse, AuthenticatedBackend, Json, JsonHandlerScopeExt, RequestHandle},
+    error::{error, ErrorNotification, ErrorNotifier},
+    pages::devices::{AppRoute, ApplicationContext, DetailsSection, Pages},
+    utils::{success, url_encode},
+};
+use drogue_client::registry::v1::Device;
+use http::{Method, StatusCode};
+use patternfly_yew::*;
+use yew::prelude::*;
+use yew_router::{agent::RouteRequest, prelude::*};
+
+#[derive(Clone, PartialEq, Properties)]
+pub struct Props {
+    pub backend: AuthenticatedBackend,
+    pub on_close: Callback<()>,
+    pub app: String,
+    pub data: Device,
+}
+
+pub enum Msg {
+    Success,
+    Error(ErrorNotification),
+    Create,
+    NewDeviceName(String),
+}
+
+pub struct CloneDialog {
+    new_device_name: String,
+    fetch_task: Option<RequestHandle>,
+}
+
+impl Component for CloneDialog {
+    type Message = Msg;
+    type Properties = Props;
+
+    fn create(_: &Context<Self>) -> Self {
+        Self {
+            fetch_task: None,
+            new_device_name: Default::default(),
+        }
+    }
+
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
+        match msg {
+            Msg::Error(msg) => {
+                BackdropDispatcher::default().close();
+                msg.toast();
+            }
+            Msg::Create => {
+                match self.create(ctx, self.new_device_name.clone(), ctx.props().app.clone()) {
+                    Ok(task) => self.fetch_task = Some(task),
+                    Err(err) => error("Failed to create", err),
+                }
+            }
+            Msg::Success => {
+                ctx.props().on_close.emit(());
+                BackdropDispatcher::default().close();
+                success("Device cloned");
+                RouteAgentDispatcher::<()>::new().send(RouteRequest::ChangeRoute(Route::from(
+                    AppRoute::Devices(Pages::Details {
+                        app: ApplicationContext::Single(ctx.props().app.clone()),
+                        name: self.new_device_name.clone(),
+                        details: DetailsSection::Overview,
+                    }),
+                )))
+            }
+            Msg::NewDeviceName(name) => self.new_device_name = name,
+        };
+        true
+    }
+
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let is_valid = matches!(self.new_device_name.len(), 1..=255);
+        let v = |ctx: ValidationContext<String>| match ctx.value.len() {
+            1..=255 => InputState::Default,
+            _ => InputState::Error,
+        };
+
+        html! (
+            <Bullseye plain=true>
+                <Modal
+                    title="New device name"
+                    variant={ModalVariant::Small}
+                    footer={html!(
+                        <Button
+                            variant={Variant::Primary}
+                            disabled={!is_valid || self.fetch_task.is_some()}
+                            r#type="submit"
+                            onclick={ctx.link().callback(|_|Msg::Create)}
+                            form="create-form"
+                        >
+                            {"Clone"}
+                        </Button>
+                    )}
+                >
+                    <Form id="create-form" method="dialog">
+                        <FormGroup>
+                            <TextInput
+                                autofocus=true
+                                validator={Validator::from(v)}
+                                onchange={ctx.link().callback(Msg::NewDeviceName)}
+                                placeholder="Device ID" />
+                        </FormGroup>
+                    </Form>
+                </Modal>
+            </Bullseye>
+        )
+    }
+}
+
+impl CloneDialog {
+    fn create(
+        &self,
+        ctx: &Context<Self>,
+        name: String,
+        app: String,
+    ) -> Result<RequestHandle, anyhow::Error> {
+        let mut data = ctx.props().data.clone();
+        data.metadata.name = name;
+
+        Ok(ctx.props().backend.request(
+            Method::POST,
+            format!("/api/registry/v1alpha1/apps/{}/devices", url_encode(app)),
+            vec![],
+            Json(data),
+            vec![],
+            ctx.callback_api::<(), _>(move |response| match response {
+                ApiResponse::Success(_, StatusCode::CREATED) => Msg::Success,
+                response => Msg::Error(response.notify("Failed to create")),
+            }),
+        )?)
+    }
+}

--- a/console-frontend/src/pages/devices/details.rs
+++ b/console-frontend/src/pages/devices/details.rs
@@ -7,7 +7,8 @@ use crate::{
     error::{error, ErrorNotification, ErrorNotifier},
     html_prop,
     pages::{
-        apps::ApplicationContext, devices::delete::DeleteConfirmation, devices::DetailsSection,
+        apps::ApplicationContext, devices::delete::DeleteConfirmation, devices::CloneDialog,
+        devices::DetailsSection,
     },
     utils::url_encode,
 };
@@ -33,6 +34,7 @@ pub enum Msg {
     Error(ErrorNotification),
     SaveEditor,
     Delete,
+    Clone,
 }
 
 pub struct Details {
@@ -93,6 +95,16 @@ impl Component for Details {
                         />
                 }),
             }),
+            Msg::Clone => BackdropDispatcher::default().open(Backdrop {
+                content: (html! {
+                    <CloneDialog
+                        backend={ctx.props().backend.clone()}
+                        data={self.content.as_ref().unwrap().as_ref().clone()}
+                        app={ctx.props().app.clone()}
+                        on_close={ctx.link().callback_once(move |_| Msg::Load)}
+                        />
+                }),
+            }),
         }
         true
     }
@@ -106,13 +118,21 @@ impl Component for Details {
                             <FlexItem>
                                 <Title>{ctx.props().name.clone()}</Title>
                             </FlexItem>
-                            <FlexItem modifiers={[FlexModifier::Align(Alignement::Right).all()]}>
-                                <Button
-                                        label="Delete"
-                                        variant={Variant::DangerSecondary}
-                                        onclick={ctx.link().callback(|_|Msg::Delete)}
-                                />
-                            </FlexItem>
+                                <FlexItem modifiers={[FlexModifier::Align(Alignement::Right).all()]}>
+                                    <Button
+                                            label="Clone"
+                                            disabled={self.content.is_none()}
+                                            variant={Variant::Secondary}
+                                            onclick={ctx.link().callback(|_|Msg::Clone)}
+                                    />
+                                </FlexItem>
+                                <FlexItem>
+                                    <Button
+                                            label="Delete"
+                                            variant={Variant::DangerSecondary}
+                                            onclick={ctx.link().callback(|_|Msg::Delete)}
+                                    />
+                                </FlexItem>
                         </Flex>
                     </Content>
                 </PageSection>

--- a/console-frontend/src/pages/devices/index.rs
+++ b/console-frontend/src/pages/devices/index.rs
@@ -6,7 +6,7 @@ use crate::{
     error::{error, ErrorNotification, ErrorNotifier},
     pages::{
         apps::ApplicationContext,
-        devices::{CreateDialog, DetailsSection, Pages},
+        devices::{CloneDialog, CreateDialog, DetailsSection, Pages},
         HasReadyState,
     },
     utils::{navigate_to, url_encode, PagingOptions},
@@ -21,6 +21,7 @@ pub struct DeviceEntry {
     pub device: Device,
     pub on_overview: Callback<()>,
     pub on_delete: Callback<()>,
+    pub on_clone: Callback<()>,
 }
 
 impl TableRenderer for DeviceEntry {
@@ -41,13 +42,22 @@ impl TableRenderer for DeviceEntry {
     }
 
     fn actions(&self) -> Vec<DropdownChildVariant> {
-        vec![html_nested! {
-        <DropdownItem
-            onclick={self.on_delete.clone()}
-        >
-            {"Delete"}
-        </DropdownItem>}
-        .into()]
+        vec![
+            html_nested! {
+            <DropdownItem
+                 onclick={self.on_clone.clone()}
+             >
+                 {"Clone"}
+             </DropdownItem>}
+            .into(),
+            html_nested! {
+            <DropdownItem
+                 onclick={self.on_delete.clone()}
+             >
+                 {"Delete"}
+             </DropdownItem>}
+            .into(),
+        ]
     }
 }
 
@@ -71,6 +81,7 @@ pub enum Msg {
 
     ShowOverview(String),
     Delete(String),
+    Clone(Device),
     TriggerModal,
 }
 
@@ -179,6 +190,16 @@ impl Component for Index {
                 Ok(task) => self.fetch_task = Some(task),
                 Err(err) => error("Failed to delete", err),
             },
+            Msg::Clone(device) => BackdropDispatcher::default().open(Backdrop {
+                content: (html! {
+                    <CloneDialog
+                        backend={ctx.props().backend.clone()}
+                        data={device}
+                        app={ctx.props().app.clone()}
+                        on_close={ctx.link().callback_once(move |_| Msg::Load)}
+                        />
+                }),
+            }),
         };
         true
     }
@@ -296,13 +317,16 @@ impl Index {
                         .map(move |device| {
                             let name = device.metadata.name.clone();
                             let name_copy = device.metadata.name.clone();
+                            let device_copy = device.clone();
                             let on_overview = link.callback_once(move |_| Msg::ShowOverview(name));
                             let on_delete = link.callback_once(move |_| Msg::Delete(name_copy));
+                            let on_clone = link.callback_once(move |_| Msg::Clone(device_copy));
 
                             DeviceEntry {
                                 device,
                                 on_overview,
                                 on_delete,
+                                on_clone,
                             }
                         })
                         .collect();

--- a/console-frontend/src/pages/devices/mod.rs
+++ b/console-frontend/src/pages/devices/mod.rs
@@ -1,8 +1,10 @@
+mod clone;
 mod create;
 mod delete;
 mod details;
 mod index;
 
+pub use clone::*;
 pub use create::*;
 pub use details::*;
 pub use index::*;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12406409/181042701-3d24cd94-150c-4e1c-9389-56f06819ffb3.png)

![image](https://user-images.githubusercontent.com/12406409/181042776-e30f589a-137e-473e-931f-b8caf1e4b130.png)

It copies the `Device` object, changing just the name. I also added an entry in the dropdown menu in the devices list

Improvement : `clone.rs` could be merged with `create.rs` easily