### PR TITLE
add filters for device and channel in the spy

### DIFF
--- a/console-frontend/src/components/spy.rs
+++ b/console-frontend/src/components/spy.rs
@@ -110,8 +110,8 @@ impl Component for Spy {
                 // log::debug!("Pushing event: {:?}", event);
                 self.total_received += 1;
                 let entry = Entry(*event);
-                if (self.device == entry.device() || self.device.is_empty())
-                    && (self.channel == entry.channel() || self.channel.is_empty())
+                if (self.device.is_empty() || self.device == entry.device())
+                    && (self.channel.is_empty() || self.channel == entry.channel())
                 {
                     self.events.insert(0, entry);
                 }

--- a/console-frontend/src/console.rs
+++ b/console-frontend/src/console.rs
@@ -270,6 +270,7 @@ impl Component for Console {
                                     />},
                                     AppRoute::Devices(pages::devices::Pages::Details{app, name, details}) => html!{<pages::devices::Details
                                         backend={backend.clone()}
+                                        endpoints={endpoints.clone()}
                                         app={url_decode(&app.to_string())}
                                         name={url_decode(&name)}
                                         details={details}

--- a/console-frontend/src/pages/devices/debug.rs
+++ b/console-frontend/src/pages/devices/debug.rs
@@ -1,0 +1,35 @@
+use crate::{backend::BackendInformation, components::spy::Spy};
+use drogue_cloud_console_common::EndpointInformation;
+use yew::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Properties)]
+pub struct Props {
+    pub backend: BackendInformation,
+    pub endpoints: EndpointInformation,
+    pub application: String,
+    pub device: String,
+}
+
+pub enum Msg {}
+
+pub struct Debug {}
+
+impl Component for Debug {
+    type Message = Msg;
+    type Properties = Props;
+
+    fn create(_: &Context<Self>) -> Self {
+        Self {}
+    }
+
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        html! (
+            <Spy
+                backend={ctx.props().backend.clone()}
+                endpoints={ctx.props().endpoints.clone()}
+                application={ctx.props().application.clone()}
+                device={ctx.props().device.clone()}
+                />
+        )
+    }
+}

--- a/console-frontend/src/pages/devices/details.rs
+++ b/console-frontend/src/pages/devices/details.rs
@@ -7,21 +7,24 @@ use crate::{
     error::{error, ErrorNotification, ErrorNotifier},
     html_prop,
     pages::{
-        apps::ApplicationContext, devices::delete::DeleteConfirmation, devices::CloneDialog,
-        devices::DetailsSection,
+        apps::ApplicationContext, devices::debug, devices::delete::DeleteConfirmation,
+        devices::CloneDialog, devices::DetailsSection,
     },
     utils::url_encode,
 };
 use drogue_client::registry::v1::Device;
+use drogue_cloud_console_common::EndpointInformation;
 use http::Method;
 use monaco::{api::*, sys::editor::BuiltinTheme, yew::CodeEditor};
 use patternfly_yew::*;
+use std::ops::Deref;
 use std::rc::Rc;
 use yew::prelude::*;
 
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct Props {
     pub backend: AuthenticatedBackend,
+    pub endpoints: EndpointInformation,
     pub app: String,
     pub name: String,
     pub details: DetailsSection,
@@ -225,6 +228,7 @@ impl Details {
                         >
                         <TabRouterItem<DetailsSection> to={DetailsSection::Overview} label="Overview"/>
                         <TabRouterItem<DetailsSection> to={DetailsSection::Yaml} label="YAML"/>
+                        <TabRouterItem<DetailsSection> to={DetailsSection::Debug} label="Events"/>
                     </DevicesTabs>
                 </PageSection>
                 <PageSection>
@@ -232,6 +236,7 @@ impl Details {
                     match ctx.props().details {
                         DetailsSection::Overview => self.render_overview(device),
                         DetailsSection::Yaml => self.render_editor(ctx),
+                        DetailsSection::Debug => self.render_debug(ctx),
                     }
                 }
                 </PageSection>
@@ -295,5 +300,16 @@ impl Details {
             </Stack>
             </>
         };
+    }
+
+    fn render_debug(&self, ctx: &Context<Self>) -> Html {
+        html! (
+            <debug::Debug
+                backend={ctx.props().backend.deref().clone()}
+                application={ctx.props().app.clone()}
+                endpoints={ctx.props().endpoints.clone()}
+                device={ctx.props().name.clone()}
+                />
+        )
     }
 }

--- a/console-frontend/src/pages/devices/mod.rs
+++ b/console-frontend/src/pages/devices/mod.rs
@@ -1,11 +1,13 @@
 mod clone;
 mod create;
+mod debug;
 mod delete;
 mod details;
 mod index;
 
 pub use clone::*;
 pub use create::*;
+pub use debug::*;
 pub use details::*;
 pub use index::*;
 
@@ -30,6 +32,8 @@ pub enum Pages {
 pub enum DetailsSection {
     #[to = "yaml"]
     Yaml,
+    #[to = "debug"]
+    Debug,
     #[end]
     Overview,
 }


### PR DESCRIPTION
Allow to filter events by device and channels.
The filters are live so no need to reconnect the spy, just type away ! 

![image](https://user-images.githubusercontent.com/12406409/191478145-f40e4ab6-6fe3-42e7-a881-80e2d13f7cad.png)

I also added a tab in the device details, to have a shortcut : 
![image](https://user-images.githubusercontent.com/12406409/191482957-93c91f90-d537-4f30-8577-45653bd0a1a2.png)
