### PR TITLE
Console: Allow adding description when creating access keys

### DIFF
--- a/console-frontend/src/pages/access_tokens/create.rs
+++ b/console-frontend/src/pages/access_tokens/create.rs
@@ -1,0 +1,117 @@
+use crate::backend::Nothing;
+use crate::{
+    backend::{ApiResponse, AuthenticatedBackend, Json, JsonHandlerScopeExt, RequestHandle},
+    error::{error, ErrorNotification, ErrorNotifier},
+    pages::access_tokens::success::AccessTokenCreatedSuccessModal,
+};
+use drogue_cloud_service_api::token::AccessTokenCreated;
+use http::Method;
+use patternfly_yew::*;
+use yew::prelude::*;
+
+#[derive(Clone, PartialEq, Properties)]
+pub struct Props {
+    pub backend: AuthenticatedBackend,
+    pub on_close: Callback<()>,
+}
+
+pub enum Msg {
+    Success(AccessTokenCreated),
+    Error(ErrorNotification),
+    Create,
+    Description(String),
+}
+
+pub struct AccessTokenCreateModal {
+    description: String,
+
+    fetch_task: Option<RequestHandle>,
+}
+
+impl Component for AccessTokenCreateModal {
+    type Message = Msg;
+    type Properties = Props;
+
+    fn create(_: &Context<Self>) -> Self {
+        Self {
+            fetch_task: None,
+            description: Default::default(),
+        }
+    }
+
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
+        match msg {
+            Msg::Error(msg) => {
+                BackdropDispatcher::default().close();
+                msg.toast();
+            }
+            Msg::Create => match self.create(ctx, &self.description) {
+                Ok(task) => self.fetch_task = Some(task),
+                Err(err) => error("Failed to create", err),
+            },
+            Msg::Success(token) => {
+                BackdropDispatcher::default().open(Backdrop {
+                    content: (html! {
+                        <AccessTokenCreatedSuccessModal
+                            token_secret={token.token}
+                            on_close={ctx.props().on_close.clone()}
+                            />
+                    }),
+                });
+            }
+            Msg::Description(name) => self.description = name,
+        };
+        true
+    }
+
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        html! (
+            <Bullseye plain=true>
+                <Modal
+                    title="Create a new access token"
+                    variant={ModalVariant::Small}
+                    footer={html!(
+                        <Button
+                            variant={Variant::Primary}
+                            disabled={self.fetch_task.is_some()}
+                            r#type="submit"
+                            onclick={ctx.link().callback(|_|Msg::Create)}
+                            form="create-form"
+                        >
+                            {"Create"}
+                        </Button>
+                    )}
+                >
+                    <Form id="create-form" method="dialog">
+                        <FormGroup>
+                            <TextInput
+                                autofocus=true
+                                onchange={ctx.link().callback(Msg::Description)}
+                                placeholder="Description (optional)" />
+                        </FormGroup>
+                    </Form>
+                </Modal>
+            </Bullseye>
+        )
+    }
+}
+
+impl AccessTokenCreateModal {
+    fn create(
+        &self,
+        ctx: &Context<Self>,
+        description: &str,
+    ) -> Result<RequestHandle, anyhow::Error> {
+        Ok(ctx.props().backend.request(
+            Method::POST,
+            "/api/tokens/v1alpha1",
+            vec![("description", description)],
+            Nothing,
+            vec![],
+            ctx.callback_api::<Json<AccessTokenCreated>, _>(move |response| match response {
+                ApiResponse::Success(token, _) => Msg::Success(token),
+                ApiResponse::Failure(err) => Msg::Error(err.notify("Creation failed")),
+            }),
+        )?)
+    }
+}

--- a/console-frontend/src/pages/access_tokens/success.rs
+++ b/console-frontend/src/pages/access_tokens/success.rs
@@ -35,11 +35,11 @@ impl Component for AccessTokenCreatedSuccessModal {
         html!(
             <Bullseye plain=true>
                 <Modal
-                    title="Access token successfully created"
+                    title="Success!"
                     variant={ModalVariant::Medium}
                     footer={html!(
                         <Button
-                            variant={Variant::Warning}
+                            variant={Variant::Primary}
                             r#type="submit"
                             onclick={ctx.link().callback(|_|Msg::Close)}
                         >
@@ -48,7 +48,8 @@ impl Component for AccessTokenCreatedSuccessModal {
                     )}
                 >
                     <FlexItem>
-                    <p>{" The access token value is:"}</p>
+                    <p>{"The access token was successfully created. Here is the secret value:"}</p>
+                        <br/>
                         <p>
                         <Clipboard
                             value={ctx.props().token_secret.clone()}
@@ -56,8 +57,14 @@ impl Component for AccessTokenCreatedSuccessModal {
                             name="access-token"
                             />
                         </p>
-                        <p>{"Once you close this alert, you won't have any chance to get the access token ever again."}</p>
-                         <p>{"Be sure to copy it somewhere safe."}</p>
+                        <br/>
+                        <Alert
+                            inline=true
+                            title="You won't be able to see this secret again!" r#type={Type::Warning}
+                        >
+                            {"Once you close this alert, you won't have any chance to get the access token again as we don't store it."}
+                            <p>{"Please make sure to copy it somewhere safe!"}</p>
+                        </Alert>
                     </FlexItem>
                 </Modal>
             </Bullseye>

--- a/console-frontend/src/pages/access_tokens/success.rs
+++ b/console-frontend/src/pages/access_tokens/success.rs
@@ -1,0 +1,66 @@
+use patternfly_yew::*;
+use yew::prelude::*;
+
+#[derive(Clone, PartialEq, Properties)]
+pub struct Props {
+    pub token_secret: String,
+    pub on_close: Callback<()>,
+}
+
+pub enum Msg {
+    Close,
+}
+
+pub struct AccessTokenCreatedSuccessModal;
+
+impl Component for AccessTokenCreatedSuccessModal {
+    type Message = Msg;
+    type Properties = Props;
+
+    fn create(_: &Context<Self>) -> Self {
+        Self {}
+    }
+
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
+        match msg {
+            Msg::Close => {
+                ctx.props().on_close.emit(());
+                BackdropDispatcher::default().close();
+            }
+        };
+        true
+    }
+
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        html!(
+            <Bullseye plain=true>
+                <Modal
+                    title="Access token successfully created"
+                    variant={ModalVariant::Medium}
+                    footer={html!(
+                        <Button
+                            variant={Variant::Warning}
+                            r#type="submit"
+                            onclick={ctx.link().callback(|_|Msg::Close)}
+                        >
+                            {"Close"}
+                        </Button>
+                    )}
+                >
+                    <FlexItem>
+                    <p>{" The access token value is:"}</p>
+                        <p>
+                        <Clipboard
+                            value={ctx.props().token_secret.clone()}
+                            readonly=true
+                            name="access-token"
+                            />
+                        </p>
+                        <p>{"Once you close this alert, you won't have any chance to get the access token ever again."}</p>
+                         <p>{"Be sure to copy it somewhere safe."}</p>
+                    </FlexItem>
+                </Modal>
+            </Bullseye>
+        )
+    }
+}


### PR DESCRIPTION
When clicking on the create button: 

![image](https://user-images.githubusercontent.com/12406409/193865021-7339b97d-d363-474f-b513-86111509e45d.png)

Then a confirmation modal : 
![image](https://user-images.githubusercontent.com/12406409/193865196-b2c143e7-0e23-43d6-b197-e166e4d0b37e.png)
