### PR TITLE
Add support for TLS-PSK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1549,6 +1549,7 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 [[package]]
 name = "drogue-bazaar"
 version = "0.3.0"
+source = "git+https://github.com/drogue-iot/drogue-bazaar?rev=41744d440c17ed31c333b4df915a49e3fa247f63#41744d440c17ed31c333b4df915a49e3fa247f63"
 dependencies = [
  "actix-cors",
  "actix-http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1549,7 +1549,6 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 [[package]]
 name = "drogue-bazaar"
 version = "0.3.0"
-source = "git+https://github.com/drogue-iot/drogue-bazaar?rev=e0695894f5292af86a38043aa8168cd273682ff8#e0695894f5292af86a38043aa8168cd273682ff8"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -1560,7 +1559,6 @@ dependencies = [
  "actix-web-prom",
  "anyhow",
  "async-trait",
- "bytes",
  "chrono",
  "config",
  "deadpool",
@@ -1588,7 +1586,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-postgres",
- "tokio-util",
  "tracing",
  "tracing-actix-web",
  "tracing-log",
@@ -1600,8 +1597,7 @@ dependencies = [
 [[package]]
 name = "drogue-client"
 version = "0.11.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dacba8947ca13c2d7b45b00cf88fa7614a0d71c79dbc48d20e02cb544624d24"
+source = "git+https://github.com/drogue-iot/drogue-client?rev=3e0fdb91305803c51946f8a818e4f053ab88c2c3#3e0fdb91305803c51946f8a818e4f053ab88c2c3"
 dependencies = [
  "async-trait",
  "base64 0.13.0",
@@ -1741,6 +1737,7 @@ dependencies = [
  "drogue-cloud-service-common",
  "futures",
  "http",
+ "humantime-serde",
  "log",
  "openssl",
  "prometheus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,10 +45,10 @@ testcontainers = { git = "https://github.com/testcontainers/testcontainers-rs", 
 #reqwest = { git = "https://github.com/ctron/reqwest", branch = "feature/basic_auth_wasm_1" }
 #drogue-ttn = { git = "https://github.com/drogue-iot/drogue-ttn", rev = "cf0338a344309815f0f05e0d7d76acb712445175" } # FIXME: awaiting release
 
-drogue-bazaar = { git = "https://github.com/drogue-iot/drogue-bazaar", rev = "e0695894f5292af86a38043aa8168cd273682ff8" } # FIXME: awaiting release 0.3.0
-#drogue-bazaar = { path = "../drogue-bazaar" }
+#drogue-bazaar = { git = "https://github.com/drogue-iot/drogue-bazaar", rev = "e0695894f5292af86a38043aa8168cd273682ff8" } # FIXME: awaiting release 0.3.0
+drogue-bazaar = { path = "../drogue-bazaar" }
 
-#drogue-client = { git = "https://github.com/drogue-iot/drogue-client", rev = "55135e532e4ddfdf88dfa50df73b751063740c71" } # FIXME: awaiting release 0.11.0
+drogue-client = { git = "https://github.com/drogue-iot/drogue-client", rev = "3e0fdb91305803c51946f8a818e4f053ab88c2c3" } # FIXME: awaiting release 0.11.0
 #drogue-client = { path = "../drogue-client" }
 
 operator-framework = { git = "https://github.com/ctron/operator-framework", rev = "8366506a3ed44b638f899dcce4a82ac32fcaff9e" } # FIXME: awaiting release 0.7.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,8 @@ testcontainers = { git = "https://github.com/testcontainers/testcontainers-rs", 
 #reqwest = { git = "https://github.com/ctron/reqwest", branch = "feature/basic_auth_wasm_1" }
 #drogue-ttn = { git = "https://github.com/drogue-iot/drogue-ttn", rev = "cf0338a344309815f0f05e0d7d76acb712445175" } # FIXME: awaiting release
 
-#drogue-bazaar = { git = "https://github.com/drogue-iot/drogue-bazaar", rev = "e0695894f5292af86a38043aa8168cd273682ff8" } # FIXME: awaiting release 0.3.0
-drogue-bazaar = { path = "../drogue-bazaar" }
+drogue-bazaar = { git = "https://github.com/drogue-iot/drogue-bazaar", rev = "41744d440c17ed31c333b4df915a49e3fa247f63" } # FIXME: awaiting release 0.3.0
+#drogue-bazaar = { path = "../drogue-bazaar" }
 
 drogue-client = { git = "https://github.com/drogue-iot/drogue-client", rev = "3e0fdb91305803c51946f8a818e4f053ab88c2c3" } # FIXME: awaiting release 0.11.0
 #drogue-client = { path = "../drogue-client" }

--- a/authentication-service/src/endpoints.rs
+++ b/authentication-service/src/endpoints.rs
@@ -5,7 +5,7 @@ use crate::{
 use actix_web::{web, HttpResponse};
 use drogue_cloud_service_api::auth::device::authn::{
     AuthenticationRequest, AuthenticationResponse, AuthorizeGatewayRequest,
-    AuthorizeGatewayResponse,
+    AuthorizeGatewayResponse, PreSharedKeyRequest, PreSharedKeyResponse,
 };
 use drogue_cloud_service_api::webapp as actix_web;
 use tracing::instrument;
@@ -17,6 +17,19 @@ pub async fn authenticate(
 ) -> Result<HttpResponse, actix_web::Error> {
     let result = match data.service.authenticate(req.0).await {
         Ok(outcome) => Ok(HttpResponse::Ok().json(AuthenticationResponse { outcome })),
+        Err(e) => Err(e.into()),
+    };
+
+    result
+}
+
+#[instrument(skip(data))]
+pub async fn request_key(
+    req: web::Json<PreSharedKeyRequest>,
+    data: web::Data<WebData<service::PostgresAuthenticationService>>,
+) -> Result<HttpResponse, actix_web::Error> {
+    let result = match data.service.request_key(req.0).await {
+        Ok(valid_key) => Ok(HttpResponse::Ok().json(PreSharedKeyResponse { valid_key })),
         Err(e) => Err(e.into()),
     };
 

--- a/authentication-service/src/lib.rs
+++ b/authentication-service/src/lib.rs
@@ -44,6 +44,7 @@ macro_rules! app {
             web::scope("/api/v1")
                 .wrap(Condition::new($enable_auth, $auth))
                 .service(web::resource("/auth").route(web::post().to(endpoints::authenticate)))
+                .service(web::resource("/keys").route(web::post().to(endpoints::request_key)))
                 .service(
                     web::resource("/authorize_as").route(web::post().to(endpoints::authorize_as)),
                 ),

--- a/coap-endpoint/Cargo.toml
+++ b/coap-endpoint/Cargo.toml
@@ -28,6 +28,7 @@ tokio = "1.21"
 tokio-openssl = "0.6"
 tokio-util = "0.7"
 tokio-dtls-stream-sink = "0.5"
+humantime-serde = "1"
 
 drogue-cloud-endpoint-common = { path = "../endpoint-common" }
 drogue-cloud-service-api = { path = "../service-api" }

--- a/coap-endpoint/src/lib.rs
+++ b/coap-endpoint/src/lib.rs
@@ -475,7 +475,7 @@ pub mod test {
             (
                 vec![(String::from("Rust"))],
                 None,
-                &"some auth val".as_bytes().to_vec()
+                Some(&"some auth val".as_bytes().to_vec())
             )
         );
 
@@ -485,7 +485,7 @@ pub mod test {
             (
                 vec![(String::from("Rust")), (String::from("test-1"))],
                 None,
-                &"some auth val".as_bytes().to_vec()
+                Some(&"some auth val".as_bytes().to_vec())
             )
         );
 
@@ -495,7 +495,7 @@ pub mod test {
             (
                 vec![(String::from("Rust"))],
                 Some(&"ct=30".as_bytes().to_vec()),
-                &"some auth val".as_bytes().to_vec()
+                Some(&"some auth val".as_bytes().to_vec())
             )
         );
 
@@ -508,7 +508,7 @@ pub mod test {
             (
                 vec![(String::from("Rust")), (String::from("test"))],
                 Some(&"ct=30&as=device%232".as_bytes().to_vec()),
-                &"some auth val".as_bytes().to_vec()
+                Some(&"some auth val".as_bytes().to_vec())
             )
         );
     }
@@ -521,7 +521,7 @@ pub mod test {
             (
                 vec![(String::from("Rust"))],
                 None,
-                &"some auth val".as_bytes().to_vec()
+                Some(&"some auth val".as_bytes().to_vec())
             )
         );
     }

--- a/console-frontend/Cargo.lock
+++ b/console-frontend/Cargo.lock
@@ -550,7 +550,7 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 [[package]]
 name = "drogue-bazaar"
 version = "0.3.0"
-source = "git+https://github.com/drogue-iot/drogue-bazaar?rev=e0695894f5292af86a38043aa8168cd273682ff8#e0695894f5292af86a38043aa8168cd273682ff8"
+source = "git+https://github.com/drogue-iot/drogue-bazaar?rev=41744d440c17ed31c333b4df915a49e3fa247f63#41744d440c17ed31c333b4df915a49e3fa247f63"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -579,8 +579,7 @@ dependencies = [
 [[package]]
 name = "drogue-client"
 version = "0.11.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dacba8947ca13c2d7b45b00cf88fa7614a0d71c79dbc48d20e02cb544624d24"
+source = "git+https://github.com/drogue-iot/drogue-client?rev=3e0fdb91305803c51946f8a818e4f053ab88c2c3#3e0fdb91305803c51946f8a818e4f053ab88c2c3"
 dependencies = [
  "async-trait",
  "base64 0.13.0",

--- a/console-frontend/Cargo.toml
+++ b/console-frontend/Cargo.toml
@@ -95,10 +95,10 @@ lto = true
 #patternfly-yew = { git = "https://github.com/ctron/patternfly-yew", rev = "32c809e030ca9ec5f7785dc7e0a78d574b9830f8" } # FIXME: awaiting release
 #patternfly-yew = { path = "../../patternfly-yew" }
 
-#drogue-client = { git = "https://github.com/drogue-iot/drogue-client", rev = "55135e532e4ddfdf88dfa50df73b751063740c71" } # FIXME: awaiting release
+drogue-client = { git = "https://github.com/drogue-iot/drogue-client", rev = "3e0fdb91305803c51946f8a818e4f053ab88c2c3" } # FIXME: awaiting release 0.11.0
 #drogue-client = { path = "../../drogue-client" }
 
-drogue-bazaar = { git = "https://github.com/drogue-iot/drogue-bazaar", rev = "e0695894f5292af86a38043aa8168cd273682ff8" } # FIXME: awaiting release 0.3.0
+drogue-bazaar = { git = "https://github.com/drogue-iot/drogue-bazaar", rev = "41744d440c17ed31c333b4df915a49e3fa247f63" } # FIXME: awaiting release 0.3.0
 #drogue-bazaar = { path = "../../drogue-bazaar" }
 
 #monaco = { git = "https://github.com/siku2/rust-monaco", rev = "cb20108c317976ba8c3d05b581a84efd394c3dbe" } # FIXME: awaiting release

--- a/device-management-service/src/service/mod.rs
+++ b/device-management-service/src/service/mod.rs
@@ -171,8 +171,8 @@ where
         }
 
         // extract credentials
-        if let Some(Ok(credentials)) = device.section::<registry::v1::DeviceSpecCredentials>() {
-            for credential in credentials.credentials {
+        if let Some(credentials) = device.get_credentials() {
+            for credential in credentials {
                 match credential {
                     registry::v1::Credential::UsernamePassword {
                         username, unique, ..

--- a/endpoint-common/src/lib.rs
+++ b/endpoint-common/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod auth;
 pub mod command;
 pub mod error;
+pub mod psk;
 pub mod sender;
 pub mod sink;
 pub mod x509;

--- a/endpoint-common/src/psk.rs
+++ b/endpoint-common/src/psk.rs
@@ -1,0 +1,107 @@
+use actix_web::{dev::Payload, error, FromRequest, HttpMessage, HttpRequest};
+use drogue_cloud_service_api::webapp as actix_web;
+use futures_util::future::{ready, Ready};
+
+/// Retrieve client PSK identities, possibly from a TLS stream.
+///
+/// This trait can be implemented for underlying transport mechanisms to hand over the client
+/// certificates.
+///
+/// There are default implementations for OpenSSL and RusTLS. Works with ntex and actix.
+pub trait PskIdentityRetriever {
+    fn verified_identity(&self) -> Option<Identity>;
+}
+
+impl PskIdentityRetriever for tokio::net::TcpStream {
+    fn verified_identity(&self) -> Option<Identity> {
+        // we have no certificates
+        None
+    }
+}
+
+#[cfg(feature = "rustls")]
+impl<T> PskIdentityRetriever for tokio_rustls::server::TlsStream<T> {
+    fn verified_identity(&self) -> Option<Identity> {
+        None
+    }
+}
+
+#[cfg(feature = "openssl")]
+impl<T> PskIdentityRetriever for tokio_openssl::SslStream<T> {
+    fn verified_identity(&self) -> Option<Identity> {
+        self.ssl()
+            .psk_identity()
+            .map(|i| core::str::from_utf8(i).ok())
+            .flatten()
+            .map(|s| s.try_into().ok())
+            .flatten()
+    }
+}
+
+#[cfg(feature = "openssl")]
+impl PskIdentityRetriever for tokio_dtls_stream_sink::Session {
+    fn verified_identity(&self) -> Option<Identity> {
+        self.ssl()
+            .map(|s| {
+                s.psk_identity()
+                    .map(|i| core::str::from_utf8(i).ok())
+                    .flatten()
+            })
+            .flatten()
+            .map(|s| s.try_into().ok())
+            .flatten()
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Identity {
+    application: String,
+    device: String,
+}
+
+impl Identity {
+    pub fn parse(s: &str) -> Result<Identity, ()> {
+        if let Some((d, a)) = s.split_once("@") {
+            Ok(Identity {
+                application: a.to_string(),
+                device: d.to_string(),
+            })
+        } else {
+            Err(())
+        }
+    }
+
+    pub fn application(&self) -> &str {
+        &self.application
+    }
+
+    pub fn device(&self) -> &str {
+        &self.device
+    }
+}
+
+impl TryFrom<&str> for Identity {
+    type Error = ();
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        Self::parse(s)
+    }
+}
+
+impl FromRequest for Identity {
+    type Error = actix_web::Error;
+    type Future = Ready<Result<Self, Self::Error>>;
+
+    fn from_request(req: &HttpRequest, _payload: &mut Payload) -> Self::Future {
+        let result = req.extensions().get::<Identity>().cloned();
+
+        ready(result.ok_or_else(|| error::ErrorBadRequest("Missing TLS-PSK identity")))
+    }
+}
+
+#[cfg(all(feature = "ntex", feature = "openssl"))]
+impl PskIdentityRetriever for ntex::io::IoBoxed {
+    fn verified_identity(&self) -> Option<Identity> {
+        // TODO: Not supported by ntex yet
+        None
+    }
+}

--- a/http-endpoint/src/telemetry.rs
+++ b/http-endpoint/src/telemetry.rs
@@ -3,6 +3,7 @@ use drogue_cloud_endpoint_common::{
     auth::DeviceAuthenticator,
     command::Commands,
     error::{EndpointError, HttpEndpointError},
+    psk::Identity,
     sender::{self, DownstreamSender, PublishIdPair},
     x509::ClientCertificateChain,
 };
@@ -42,6 +43,7 @@ pub async fn publish_plain(
     req: HttpRequest,
     body: web::Bytes,
     certs: Option<ClientCertificateChain>,
+    verified_identity: Option<Identity>,
 ) -> Result<HttpResponse, HttpEndpointError> {
     publish(
         sender,
@@ -53,6 +55,7 @@ pub async fn publish_plain(
         req,
         body,
         certs,
+        verified_identity,
     )
     .await
 }
@@ -67,6 +70,7 @@ pub async fn publish_tail(
     req: HttpRequest,
     body: web::Bytes,
     certs: Option<ClientCertificateChain>,
+    verified_identity: Option<Identity>,
 ) -> Result<HttpResponse, HttpEndpointError> {
     let (channel, suffix) = path.into_inner();
     publish(
@@ -79,6 +83,7 @@ pub async fn publish_tail(
         req,
         body,
         certs,
+        verified_identity,
     )
     .await
 }
@@ -95,6 +100,7 @@ pub async fn publish(
     req: HttpRequest,
     body: web::Bytes,
     certs: Option<ClientCertificateChain>,
+    verified_identity: Option<Identity>,
 ) -> Result<HttpResponse, HttpEndpointError> {
     log::debug!("Publish to '{}'", channel);
 
@@ -104,6 +110,7 @@ pub async fn publish(
             opts.common.device,
             req.headers().get(http::header::AUTHORIZATION),
             certs.map(|c| c.0),
+            verified_identity,
             opts.r#as.clone(),
         )
         .await

--- a/http-endpoint/src/ttn/mod.rs
+++ b/http-endpoint/src/ttn/mod.rs
@@ -70,6 +70,7 @@ async fn publish_uplink(
             opts.device,
             req.headers().get(http::header::AUTHORIZATION),
             cert.map(|c| c.0),
+            None,
             Some(device_id.clone()),
         )
         .await

--- a/http-endpoint/src/x509.rs
+++ b/http-endpoint/src/x509.rs
@@ -1,26 +1,29 @@
 use actix_rt::net::TcpStream;
-use drogue_cloud_endpoint_common::x509::{ClientCertificateChain, ClientCertificateRetriever};
+use drogue_cloud_endpoint_common::{
+    psk::{Identity, PskIdentityRetriever},
+    x509::{ClientCertificateChain, ClientCertificateRetriever},
+};
 use std::any::Any;
 
-pub fn from_socket(con: &dyn Any) -> Option<ClientCertificateChain> {
+pub fn from_socket(con: &dyn Any) -> (Option<Identity>, Option<ClientCertificateChain>) {
     log::debug!("Try extracting client cert");
 
     #[cfg(feature = "openssl")]
     {
         log::debug!("Trying openssl");
         if let Some(con) = con.downcast_ref::<actix_tls::accept::openssl::TlsStream<TcpStream>>() {
-            return con.client_certs();
+            return (con.verified_identity(), con.client_certs());
         }
     }
     #[cfg(feature = "rustls")]
     {
         log::debug!("Trying rustls");
         if let Some(con) = con.downcast_ref::<actix_tls::accept::openssl::TlsStream<TcpStream>>() {
-            return con.client_certs();
+            return (None, con.client_certs());
         }
     }
 
     log::warn!("No provider to extract certificates from");
 
-    None
+    (None, None)
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -792,6 +792,8 @@ async fn cmd_run(matches: &ArgMatches) -> anyhow::Result<()> {
             endpoint_pool: Default::default(),
             disable_dtls: !(key_file.is_some() && cert_bundle_file.is_some()),
             disable_client_certificates: false,
+            disable_psk: false,
+            dtls_session_timeout: None,
             cert_bundle_file,
             key_file,
         };

--- a/service-api/src/auth/device/authn.rs
+++ b/service-api/src/auth/device/authn.rs
@@ -15,6 +15,13 @@ pub struct AuthenticationRequest {
     pub r#as: Option<String>,
 }
 
+/// Requesting pre-shared keys for a device.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PreSharedKeyRequest {
+    pub application: String,
+    pub device: String,
+}
+
 /// Credentials, as presented by a device.
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum Credential {
@@ -97,6 +104,13 @@ impl AuthenticationResponse {
             outcome: Outcome::Fail,
         }
     }
+}
+
+/// The result of a key request
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PreSharedKeyResponse {
+    /// A trusted key, if available.
+    pub valid_key: Option<registry::v1::PreSharedKey>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/service-common/Cargo.toml
+++ b/service-common/Cargo.toml
@@ -29,7 +29,7 @@ openid = "0.10"
 opentelemetry = { version = "0.17", features = ["rt-tokio"] }
 pem = "1"
 prometheus = { version = "^0.13", default-features = false }
-reqwest = "0.11"
+reqwest = { version = "0.11", features = ["blocking"] }
 serde = "1"
 serde_json = "1"
 thiserror = "1"

--- a/service-common/src/client/device_auth.rs
+++ b/service-common/src/client/device_auth.rs
@@ -6,7 +6,7 @@ use drogue_client::{
 };
 use drogue_cloud_service_api::auth::device::authn::{
     AuthenticationRequest, AuthenticationResponse, AuthorizeGatewayRequest,
-    AuthorizeGatewayResponse,
+    AuthorizeGatewayResponse, PreSharedKeyRequest, PreSharedKeyResponse,
 };
 use lazy_static::lazy_static;
 use prometheus::{register_int_gauge_vec, IntGaugeVec};
@@ -23,6 +23,12 @@ lazy_static! {
         &["outcome"]
     )
     .unwrap();
+    /*pub static ref PRE_SHARED_KEY_REQUEST: IntGaugeVec = register_int_gauge_vec!(
+        "drogue_client_device_psk_request",
+        "Device pre shared key requests",
+        &["outcome"]
+    )
+    .unwrap();*/
     pub static ref AUTHORIZATION_AS: IntGaugeVec = register_int_gauge_vec!(
         "drogue_client_device_authorization_as",
         "Device authorization as operations",
@@ -37,6 +43,7 @@ pub struct ReqwestAuthenticatorClient {
     client: Client,
     auth_service_url: Url,
     auth_as_url: Url,
+    keys_url: Url,
     token_provider: Option<OpenIdTokenProvider>,
 }
 
@@ -51,8 +58,18 @@ impl ReqwestAuthenticatorClient {
             client,
             auth_service_url: url.join("auth")?,
             auth_as_url: url.join("authorize_as")?,
+            keys_url: url.join("keys")?,
             token_provider,
         })
+    }
+
+    #[instrument]
+    pub async fn request_psk(
+        &self,
+        request: PreSharedKeyRequest,
+    ) -> Result<PreSharedKeyResponse, ClientError> {
+        self.request(self.keys_url.clone(), request).await
+        //.record_outcome(&PRE_SHARED_KEY_REQUEST)
     }
 
     #[instrument]

--- a/ttn-operator/src/controller/app.rs
+++ b/ttn-operator/src/controller/app.rs
@@ -281,8 +281,8 @@ impl<'a> ApplicationReconciler<'a> {
     ) -> Result<String, ReconcileError> {
         // find a current password
 
-        let password = match gateway.section::<registry::v1::DeviceSpecCredentials>() {
-            Some(Ok(creds)) => creds.credentials.iter().find_map(|cred| match cred {
+        let password = match gateway.get_credentials() {
+            Some(creds) => creds.iter().find_map(|cred| match cred {
                 registry::v1::Credential::Password(pwd) => Some(pwd.clone()),
                 _ => None,
             }),
@@ -295,11 +295,9 @@ impl<'a> ApplicationReconciler<'a> {
             password
         } else {
             let password = utils::random_password();
-            gateway.set_section(registry::v1::DeviceSpecCredentials {
-                credentials: vec![registry::v1::Credential::Password(
-                    registry::v1::Password::Plain(password.clone()),
-                )],
-            })?;
+            gateway.add_credential(registry::v1::Credential::Password(
+                registry::v1::Password::Plain(password.clone()),
+            ))?;
             password
         };
 


### PR DESCRIPTION
* [x] Use drogue-client with support for new schema
* [x] Use common lookup mechanism for credentials, which support fallback to old schema.
* [x] Implement key selection according to RFC
* [x] Add support to CoAP endpoint
* [ ] Add support to MQTT endpoint
* [x] Add support to HTTP endpoint
* [x] Make feature configurable