### PR TITLE
Tls psk resource lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1549,7 +1549,7 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 [[package]]
 name = "drogue-bazaar"
 version = "0.3.0"
-source = "git+https://github.com/drogue-iot/drogue-bazaar?rev=41744d440c17ed31c333b4df915a49e3fa247f63#41744d440c17ed31c333b4df915a49e3fa247f63"
+source = "git+https://github.com/drogue-iot/drogue-bazaar?rev=55202dc51f303f142cef004ba0e02a335f0f7849#55202dc51f303f142cef004ba0e02a335f0f7849"
 dependencies = [
  "actix-cors",
  "actix-http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1739,6 +1739,7 @@ dependencies = [
  "futures",
  "http",
  "humantime-serde",
+ "lazy_static",
  "log",
  "openssl",
  "prometheus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,8 @@ testcontainers = { git = "https://github.com/testcontainers/testcontainers-rs", 
 #reqwest = { git = "https://github.com/ctron/reqwest", branch = "feature/basic_auth_wasm_1" }
 #drogue-ttn = { git = "https://github.com/drogue-iot/drogue-ttn", rev = "cf0338a344309815f0f05e0d7d76acb712445175" } # FIXME: awaiting release
 
-drogue-bazaar = { git = "https://github.com/drogue-iot/drogue-bazaar", rev = "41744d440c17ed31c333b4df915a49e3fa247f63" } # FIXME: awaiting release 0.3.0
+
+drogue-bazaar = { git = "https://github.com/drogue-iot/drogue-bazaar", rev = "55202dc51f303f142cef004ba0e02a335f0f7849" } # FIXME: awaiting release 0.3.0
 #drogue-bazaar = { path = "../drogue-bazaar" }
 
 drogue-client = { git = "https://github.com/drogue-iot/drogue-client", rev = "3e0fdb91305803c51946f8a818e4f053ab88c2c3" } # FIXME: awaiting release 0.11.0

--- a/authentication-service/src/endpoints.rs
+++ b/authentication-service/src/endpoints.rs
@@ -29,7 +29,7 @@ pub async fn request_key(
     data: web::Data<WebData<service::PostgresAuthenticationService>>,
 ) -> Result<HttpResponse, actix_web::Error> {
     let result = match data.service.request_key(req.0).await {
-        Ok(valid_key) => Ok(HttpResponse::Ok().json(PreSharedKeyResponse { valid_key })),
+        Ok(outcome) => Ok(HttpResponse::Ok().json(PreSharedKeyResponse { outcome })),
         Err(e) => Err(e.into()),
     };
 

--- a/coap-endpoint/Cargo.toml
+++ b/coap-endpoint/Cargo.toml
@@ -17,6 +17,7 @@ cloudevents-sdk = "0.5"
 coap-lite = "0.11"
 drogue-client = "0.11.0-alpha.1"
 openssl = { version = "0.10", features = ["v111"] }
+lazy_static = "1.4"
 futures = "0.3"
 http = "0.2"
 log = "0.4"

--- a/coap-endpoint/src/telemetry.rs
+++ b/coap-endpoint/src/telemetry.rs
@@ -3,7 +3,7 @@ use coap_lite::{CoapOption, CoapRequest, CoapResponse};
 use drogue_cloud_endpoint_common::{
     command::Commands,
     error::EndpointError,
-    psk::Identity,
+    psk::VerifiedIdentity,
     sender::{self, DownstreamSender, ToPublishId},
     x509::ClientCertificateChain,
 };
@@ -40,7 +40,7 @@ pub async fn publish_plain(
     req: CoapRequest<SocketAddr>,
     auth: Option<&Vec<u8>>,
     certs: Option<ClientCertificateChain>,
-    verified_identity: Option<Identity>,
+    verified_identity: Option<VerifiedIdentity>,
 ) -> Result<Option<CoapResponse>, CoapEndpointError> {
     publish(
         sender,
@@ -66,7 +66,7 @@ pub async fn publish_tail(
     req: CoapRequest<SocketAddr>,
     auth: Option<&Vec<u8>>,
     certs: Option<ClientCertificateChain>,
-    verified_identity: Option<Identity>,
+    verified_identity: Option<VerifiedIdentity>,
 ) -> Result<Option<CoapResponse>, CoapEndpointError> {
     let (channel, suffix) = path;
     publish(
@@ -95,7 +95,7 @@ pub async fn publish(
     req: CoapRequest<SocketAddr>,
     auth: Option<&Vec<u8>>,
     certs: Option<ClientCertificateChain>,
-    verified_identity: Option<Identity>,
+    verified_identity: Option<VerifiedIdentity>,
 ) -> Result<Option<CoapResponse>, CoapEndpointError> {
     log::debug!("Publish to '{}'", channel);
 

--- a/endpoint-common/src/psk.rs
+++ b/endpoint-common/src/psk.rs
@@ -1,4 +1,5 @@
 use actix_web::{dev::Payload, error, FromRequest, HttpMessage, HttpRequest};
+use drogue_client::registry;
 use drogue_cloud_service_api::webapp as actix_web;
 use futures_util::future::{ready, Ready};
 
@@ -9,47 +10,47 @@ use futures_util::future::{ready, Ready};
 ///
 /// There are default implementations for OpenSSL and RusTLS. Works with ntex and actix.
 pub trait PskIdentityRetriever {
-    fn verified_identity(&self) -> Option<Identity>;
+    fn verified_identity(&self) -> Option<VerifiedIdentity>;
 }
 
 impl PskIdentityRetriever for tokio::net::TcpStream {
-    fn verified_identity(&self) -> Option<Identity> {
-        // we have no certificates
+    fn verified_identity(&self) -> Option<VerifiedIdentity> {
         None
     }
 }
 
 #[cfg(feature = "rustls")]
 impl<T> PskIdentityRetriever for tokio_rustls::server::TlsStream<T> {
-    fn verified_identity(&self) -> Option<Identity> {
+    fn verified_identity(&self) -> Option<VerifiedIdentity> {
         None
     }
 }
 
 #[cfg(feature = "openssl")]
+lazy_static::lazy_static! {
+    static ref RESOURCE_INDEX: open_ssl::ex_data::Index<open_ssl::ssl::Ssl, VerifiedIdentity> =
+        open_ssl::ssl::Ssl::new_ex_index().unwrap();
+}
+
+#[cfg(feature = "openssl")]
+pub fn set_ssl_identity(ssl: &mut open_ssl::ssl::SslRef, identity: VerifiedIdentity) {
+    ssl.set_ex_data(*RESOURCE_INDEX, identity);
+}
+
+#[cfg(feature = "openssl")]
 impl<T> PskIdentityRetriever for tokio_openssl::SslStream<T> {
-    fn verified_identity(&self) -> Option<Identity> {
-        self.ssl()
-            .psk_identity()
-            .map(|i| core::str::from_utf8(i).ok())
-            .flatten()
-            .map(|s| s.try_into().ok())
-            .flatten()
+    fn verified_identity(&self) -> Option<VerifiedIdentity> {
+        self.ssl().ex_data(*RESOURCE_INDEX).cloned()
     }
 }
 
 #[cfg(feature = "openssl")]
 impl PskIdentityRetriever for tokio_dtls_stream_sink::Session {
-    fn verified_identity(&self) -> Option<Identity> {
+    fn verified_identity(&self) -> Option<VerifiedIdentity> {
         self.ssl()
-            .map(|s| {
-                s.psk_identity()
-                    .map(|i| core::str::from_utf8(i).ok())
-                    .flatten()
-            })
+            .map(|ssl| ssl.ex_data(*RESOURCE_INDEX))
             .flatten()
-            .map(|s| s.try_into().ok())
-            .flatten()
+            .cloned()
     }
 }
 
@@ -87,20 +88,26 @@ impl TryFrom<&str> for Identity {
     }
 }
 
-impl FromRequest for Identity {
+impl FromRequest for VerifiedIdentity {
     type Error = actix_web::Error;
     type Future = Ready<Result<Self, Self::Error>>;
 
     fn from_request(req: &HttpRequest, _payload: &mut Payload) -> Self::Future {
-        let result = req.extensions().get::<Identity>().cloned();
+        let result = req.extensions().get::<VerifiedIdentity>().cloned();
 
         ready(result.ok_or_else(|| error::ErrorBadRequest("Missing TLS-PSK identity")))
     }
 }
 
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct VerifiedIdentity {
+    pub application: registry::v1::Application,
+    pub device: registry::v1::Device,
+}
+
 #[cfg(all(feature = "ntex", feature = "openssl"))]
 impl PskIdentityRetriever for ntex::io::IoBoxed {
-    fn verified_identity(&self) -> Option<Identity> {
+    fn verified_identity(&self) -> Option<VerifiedIdentity> {
         // TODO: Not supported by ntex yet
         None
     }

--- a/http-endpoint/src/lib.rs
+++ b/http-endpoint/src/lib.rs
@@ -12,6 +12,7 @@ use drogue_cloud_endpoint_common::{
     sender::{DownstreamSender, ExternalClientPoolConfig},
     sink::KafkaSink,
 };
+use drogue_cloud_service_api::auth::device::authn::PreSharedKeyOutcome;
 use drogue_cloud_service_api::{
     kafka::KafkaClientConfig,
     webapp::{self as actix_web},
@@ -87,9 +88,9 @@ pub async fn run(config: Config, startup: &mut dyn Startup) -> anyhow::Result<()
                     });
 
                     if let Ok(response) = response {
-                        if let Some(valid) = response.valid_key {
-                            to_copy = std::cmp::min(valid.key.len(), secret_mut.len());
-                            secret_mut[..to_copy].copy_from_slice(&valid.key[..to_copy]);
+                        if let PreSharedKeyOutcome::Found { app, device, key } = response.outcome {
+                            to_copy = std::cmp::min(key.key.len(), secret_mut.len());
+                            secret_mut[..to_copy].copy_from_slice(&key.key[..to_copy]);
                         }
                     }
                 }

--- a/http-endpoint/src/telemetry.rs
+++ b/http-endpoint/src/telemetry.rs
@@ -3,7 +3,7 @@ use drogue_cloud_endpoint_common::{
     auth::DeviceAuthenticator,
     command::Commands,
     error::{EndpointError, HttpEndpointError},
-    psk::Identity,
+    psk::VerifiedIdentity,
     sender::{self, DownstreamSender, PublishIdPair},
     x509::ClientCertificateChain,
 };
@@ -43,7 +43,7 @@ pub async fn publish_plain(
     req: HttpRequest,
     body: web::Bytes,
     certs: Option<ClientCertificateChain>,
-    verified_identity: Option<Identity>,
+    verified_identity: Option<VerifiedIdentity>,
 ) -> Result<HttpResponse, HttpEndpointError> {
     publish(
         sender,
@@ -70,7 +70,7 @@ pub async fn publish_tail(
     req: HttpRequest,
     body: web::Bytes,
     certs: Option<ClientCertificateChain>,
-    verified_identity: Option<Identity>,
+    verified_identity: Option<VerifiedIdentity>,
 ) -> Result<HttpResponse, HttpEndpointError> {
     let (channel, suffix) = path.into_inner();
     publish(
@@ -100,7 +100,7 @@ pub async fn publish(
     req: HttpRequest,
     body: web::Bytes,
     certs: Option<ClientCertificateChain>,
-    verified_identity: Option<Identity>,
+    verified_identity: Option<VerifiedIdentity>,
 ) -> Result<HttpResponse, HttpEndpointError> {
     log::debug!("Publish to '{}'", channel);
 

--- a/http-endpoint/src/x509.rs
+++ b/http-endpoint/src/x509.rs
@@ -1,11 +1,11 @@
 use actix_rt::net::TcpStream;
 use drogue_cloud_endpoint_common::{
-    psk::{Identity, PskIdentityRetriever},
+    psk::{PskIdentityRetriever, VerifiedIdentity},
     x509::{ClientCertificateChain, ClientCertificateRetriever},
 };
 use std::any::Any;
 
-pub fn from_socket(con: &dyn Any) -> (Option<Identity>, Option<ClientCertificateChain>) {
+pub fn from_socket(con: &dyn Any) -> (Option<VerifiedIdentity>, Option<ClientCertificateChain>) {
     log::debug!("Try extracting client cert");
 
     #[cfg(feature = "openssl")]

--- a/mqtt-endpoint/src/service/app.rs
+++ b/mqtt-endpoint/src/service/app.rs
@@ -7,7 +7,7 @@ use drogue_client::{
 use drogue_cloud_endpoint_common::{
     command::Commands,
     error::EndpointError,
-    psk::{Identity, PskIdentityRetriever},
+    psk::{PskIdentityRetriever, VerifiedIdentity},
     sender::DownstreamSender,
     x509::{ClientCertificateChain, ClientCertificateRetriever},
 };
@@ -40,7 +40,7 @@ impl App {
         password: Option<&[u8]>,
         client_id: &str,
         certs: Option<ClientCertificateChain>,
-        verified_identity: Option<Identity>,
+        verified_identity: Option<VerifiedIdentity>,
     ) -> Result<AuthOutcome, EndpointError> {
         let password = password
             .map(|p| String::from_utf8(p.to_vec()))

--- a/service-api/src/auth/device/authn.rs
+++ b/service-api/src/auth/device/authn.rs
@@ -110,7 +110,17 @@ impl AuthenticationResponse {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PreSharedKeyResponse {
     /// A trusted key, if available.
-    pub valid_key: Option<registry::v1::PreSharedKey>,
+    pub outcome: PreSharedKeyOutcome,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum PreSharedKeyOutcome {
+    Found {
+        app: registry::v1::Application,
+        device: registry::v1::Device,
+        key: registry::v1::PreSharedKey,
+    },
+    NotFound,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
As discussed in chat:

* Return application and device on key lookup
* Store app and device in SSL session extra data
* Lookup app and device from session data

This well make app + device auth valid for the duration of the TLS/DTLS session. If a key is revoked, the device will not require re-authentication until session timeout (60 secs by default).