### PR TITLE
[refactor] drop unused whoami path and drop redundant endpoints info

### DIFF
--- a/console-backend/api/index.yaml
+++ b/console-backend/api/index.yaml
@@ -360,30 +360,6 @@ paths:
   # ## Admin
   #
 
-  /api/admin/v1alpha1/user/whoami:
-    get:
-      tags:
-        - User administration
-      description: Get information about the current user.
-      responses:
-        200:
-          description: Information about the current user.
-          content:
-            'application/json':
-              schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                    description: |
-                      The ID of the current user.
-
-                      NOTE: This ID may be different to the name of the user.
-                required:
-                  - id
-        403:
-          description: In case the user is not logged in.
-
   /api/admin/v1alpha1/apps/{application}/transfer-ownership:
     parameters:
       - $ref: '#/components/parameters/ApplicationName'

--- a/console-backend/src/admin.rs
+++ b/console-backend/src/admin.rs
@@ -1,9 +1,0 @@
-use actix_web::HttpResponse;
-use drogue_cloud_service_api::auth::user::UserInformation;
-use serde_json::json;
-
-pub async fn whoami(user: UserInformation) -> Result<HttpResponse, actix_web::Error> {
-    Ok(HttpResponse::Ok().json(json!({
-        "id": user.user_id(),
-    })))
-}

--- a/console-backend/src/info.rs
+++ b/console-backend/src/info.rs
@@ -21,7 +21,8 @@ impl DemoFetcher {
     }
 }
 
-pub async fn get_info(
+#[get("/drogue-endpoints")]
+pub async fn get_public_endpoints(
     endpoints: web::Data<Endpoints>,
     demos: web::Data<DemoFetcher>,
 ) -> impl Responder {
@@ -30,11 +31,6 @@ pub async fn get_info(
         demos: demos.get_ref().get_demos().await,
     };
     HttpResponse::Ok().json(info)
-}
-
-#[get("/drogue-endpoints")]
-pub async fn get_public_endpoints(endpoints: web::Data<Endpoints>) -> impl Responder {
-    HttpResponse::Ok().json(endpoints)
 }
 
 #[get("/drogue-version")]

--- a/console-backend/src/lib.rs
+++ b/console-backend/src/lib.rs
@@ -1,4 +1,3 @@
-mod admin;
 mod api;
 mod demos;
 mod info;
@@ -222,19 +221,7 @@ pub async fn configurator(
                             >),
                         )),
                 )
-                .service(
-                    web::scope("/api/admin/v1alpha1")
-                        .wrap(auth.clone())
-                        .service(web::resource("/user/whoami").route(web::get().to(admin::whoami))),
-                )
                 // everything from here on is unauthenticated or not using the middleware
-                .service(
-                    web::scope("/api/console/v1alpha1").service(
-                        web::resource("/info")
-                            .wrap(auth)
-                            .route(web::get().to(info::get_info)),
-                    ),
-                )
                 .service(index)
                 .service(
                     web::scope("/.well-known")


### PR DESCRIPTION
As far as I can see, the whoami endpoint is not used anymore in the console as it pull the username from the oauth token claim. 
In the case where we need to keep it (to use with an access token? Is that a use case ? ) we could move it to `/api/console/v1alpha1/user/whoami` in order to prevent the clash with the apps managements paths.  