### PR TITLE
Add infrastructure for more MQTT dialects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,7 +1465,7 @@ dependencies = [
 [[package]]
 name = "drogue-client"
 version = "0.12.0"
-source = "git+https://github.com/drogue-iot/drogue-client?rev=798c968f0a63a0debcff9965c66b361e85946458#798c968f0a63a0debcff9965c66b361e85946458"
+source = "git+https://github.com/drogue-iot/drogue-client?rev=c3e5fc6e0ef1781f8362394a114b72738990d00d#c3e5fc6e0ef1781f8362394a114b72738990d00d"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2103,6 +2103,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "url",
  "uuid",
  "webpki",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ testcontainers = { git = "https://github.com/testcontainers/testcontainers-rs", 
 drogue-bazaar = { git = "https://github.com/drogue-iot/drogue-bazaar", rev = "d19ad32f200938aeb5d7081ee3385ee40c5ae0ff" } # FIXME: awaiting release 0.4.0
 #drogue-bazaar = { path = "../drogue-bazaar" }
 
-drogue-client = { git = "https://github.com/drogue-iot/drogue-client", rev = "798c968f0a63a0debcff9965c66b361e85946458" } # FIXME: awaiting release 0.12.0
+drogue-client = { git = "https://github.com/drogue-iot/drogue-client", rev = "c3e5fc6e0ef1781f8362394a114b72738990d00d" } # FIXME: awaiting release 0.12.0
 #drogue-client = { path = "../drogue-client" }
 
 operator-framework = { git = "https://github.com/ctron/operator-framework", rev = "8366506a3ed44b638f899dcce4a82ac32fcaff9e" } # FIXME: awaiting release 0.7.0

--- a/endpoint-common/src/auth.rs
+++ b/endpoint-common/src/auth.rs
@@ -263,11 +263,7 @@ impl DeviceAuthenticator {
         C: AsRef<str> + Debug,
     {
         log::debug!(
-            "Authenticate MQTT - username: {:?}, password: {:?}, client_id: {:?}, certs: {:?}",
-            username,
-            password,
-            client_id,
-            certs
+            "Authenticate MQTT - username: {username:?}, password: {password:?}, client_id: {client_id:?}, certs: {certs:?}, verified_identity: {verified_identity:?}",
         );
 
         match (

--- a/endpoint-common/src/auth.rs
+++ b/endpoint-common/src/auth.rs
@@ -303,6 +303,8 @@ impl DeviceAuthenticator {
             }
             // Client cert only
             (None, None, _, Some(certs), None) => self.authenticate_cert(certs.0).await,
+            // Client cert plus username
+            (Some(_username), None, _, Some(certs), None) => self.authenticate_cert(certs.0).await,
             // TLS-PSK verified identity
             (None, None, _, None, Some(verified_identity)) => {
                 self.authenticate_verified_identity(verified_identity)

--- a/endpoint-common/src/command/source.rs
+++ b/endpoint-common/src/command/source.rs
@@ -38,6 +38,8 @@ impl KafkaCommandSource {
     where
         D: CommandDispatcher + Send + Sync + 'static,
     {
+        log::info!("Starting Kafka command source");
+
         let mut source = EventStream::<AutoAck>::new(EventStreamConfig {
             kafka: KafkaConfig {
                 topic: config.topic,

--- a/mqtt-endpoint/Cargo.toml
+++ b/mqtt-endpoint/Cargo.toml
@@ -33,6 +33,7 @@ serde_json = "1"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }
 tracing = { version = "0.1", features = ["log-always"] }
+url = "2"
 uuid = { version = "1", features = ["v4"] }
 webpki = "0.22"
 

--- a/mqtt-endpoint/src/service/app.rs
+++ b/mqtt-endpoint/src/service/app.rs
@@ -17,8 +17,7 @@ use drogue_cloud_endpoint_common::{
 };
 use drogue_cloud_mqtt_common::{
     error::ServerError,
-    mqtt,
-    mqtt::{AckOptions, Connect, ConnectAck, Service, Sink},
+    mqtt::{AckOptions, Connect, ConnectAck, Service},
 };
 use drogue_cloud_service_api::{
     auth::device::authn::Outcome as AuthOutcome,

--- a/mqtt-endpoint/src/service/app.rs
+++ b/mqtt-endpoint/src/service/app.rs
@@ -188,10 +188,6 @@ impl Service<Session> for App {
     ) -> Result<ConnectAck<Session>, ServerError> {
         log::info!("new connection: {:?}", connect);
 
-        if !connect.clean_session() {
-            return Err(ServerError::UnsupportedOperation);
-        }
-
         let certs = connect.io().client_certs();
         let verified_identity = if self.disable_psk {
             None
@@ -246,6 +242,7 @@ impl Service<Session> for App {
                         wildcard_subscription_available: Some(true),
                         shared_subscription_available: Some(false),
                         subscription_identifiers_available: Some(false),
+                        session_present: false,
                         ..Default::default()
                     },
                 })

--- a/mqtt-endpoint/src/service/session/dialect/az.rs
+++ b/mqtt-endpoint/src/service/session/dialect/az.rs
@@ -10,10 +10,39 @@ pub fn split_topic(path: &str) -> (&str, Vec<(Cow<str>, Cow<str>)>) {
             (topic, query.collect())
         } else {
             // last one is a regular one
-            (path, vec![])
+            (path.trim_end_matches('/'), vec![])
         }
     } else {
         // single topic segment
         (path, vec![])
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    #[test]
+    fn test_plain() {
+        assert_eq!(split_topic("foo/bar"), ("foo/bar", vec![]));
+    }
+
+    #[test]
+    fn test_plain_slash() {
+        assert_eq!(split_topic("foo/bar/"), ("foo/bar", vec![]));
+    }
+
+    #[test]
+    fn test_plain_slash_q() {
+        assert_eq!(split_topic("foo/bar/?"), ("foo/bar", vec![]));
+    }
+
+    #[test]
+    fn test_properties() {
+        assert_eq!(
+            split_topic("foo/bar/?baz=123"),
+            ("foo/bar", vec![("baz".into(), "123".into())])
+        );
     }
 }

--- a/mqtt-endpoint/src/service/session/dialect/az.rs
+++ b/mqtt-endpoint/src/service/session/dialect/az.rs
@@ -2,6 +2,8 @@ use super::*;
 use std::borrow::Cow;
 
 /// Azure IoT dialect.
+///
+/// NOTE: This is experimental.
 pub struct Azure;
 
 impl ConnectValidator for Azure {

--- a/mqtt-endpoint/src/service/session/dialect/az.rs
+++ b/mqtt-endpoint/src/service/session/dialect/az.rs
@@ -1,0 +1,19 @@
+use std::borrow::Cow;
+
+/// Split an Azure topic, which might carry a "bag of properties" as the last topic segment
+pub fn split_topic(path: &str) -> (&str, Vec<(Cow<str>, Cow<str>)>) {
+    if let Some((topic, last)) = path.rsplit_once('/') {
+        // at least two segments
+        if last.starts_with("?") {
+            // last one is a bag of properties
+            let query = url::form_urlencoded::parse(&last.as_bytes()[1..]);
+            (topic, query.collect())
+        } else {
+            // last one is a regular one
+            (path, vec![])
+        }
+    } else {
+        // single topic segment
+        (path, vec![])
+    }
+}

--- a/mqtt-endpoint/src/service/session/dialect/c8y.rs
+++ b/mqtt-endpoint/src/service/session/dialect/c8y.rs
@@ -1,6 +1,8 @@
 use super::*;
 
 /// Cumulocity dialect.
+///
+/// NOTE: This is experimental.
 pub struct Cumulocity;
 
 impl PublishTopicParser for Cumulocity {

--- a/mqtt-endpoint/src/service/session/dialect/c8y.rs
+++ b/mqtt-endpoint/src/service/session/dialect/c8y.rs
@@ -1,0 +1,43 @@
+use super::*;
+
+/// Cumulocity dialect.
+pub struct Cumulocity;
+
+impl PublishTopicParser for Cumulocity {
+    fn parse_publish<'a>(&self, path: &'a str) -> Result<ParsedPublishTopic<'a>, ParseError> {
+        let topic = path.split('/').collect::<Vec<_>>();
+        log::debug!("C8Y: {topic:?}",);
+
+        match topic.as_slice() {
+            [""] => Err(ParseError::Empty),
+            ["s", "us"] => Ok(ParsedPublishTopic {
+                channel: "c8y",
+                device: None,
+                properties: vec![],
+            }),
+            ["s", "us", as_device] => Ok(ParsedPublishTopic {
+                channel: "c8y",
+                device: Some(as_device),
+                properties: vec![],
+            }),
+            _ => Err(ParseError::Syntax),
+        }
+    }
+}
+
+impl SubscribeTopicParser for Cumulocity {
+    fn parse_subscribe<'a>(&self, path: &'a str) -> Result<ParsedSubscribeTopic<'a>, ParseError> {
+        log::debug!("c8y: {path}");
+        match path.split('/').collect::<Vec<_>>().as_slice() {
+            [] => Err(ParseError::Empty),
+            ["s", "e"] => Ok(ParsedSubscribeTopic {
+                filter: SubscribeFilter {
+                    device: DeviceFilter::Device,
+                    command: None,
+                },
+                encoder: SubscriptionTopicEncoder::new(DefaultCommandTopicEncoder(false)),
+            }),
+            _ => Err(ParseError::Syntax),
+        }
+    }
+}

--- a/mqtt-endpoint/src/service/session/dialect/drogue.rs
+++ b/mqtt-endpoint/src/service/session/dialect/drogue.rs
@@ -1,0 +1,81 @@
+use super::*;
+use drogue_cloud_endpoint_common::command::Command;
+
+/// Drogue IoT v1 dialect.
+pub struct DrogueV1;
+
+impl PublishTopicParser for DrogueV1 {
+    fn parse_publish<'a>(&self, path: &'a str) -> Result<ParsedPublishTopic<'a>, ParseError> {
+        // This should mimic the behavior of the current parser
+        let topic = path.split('/').collect::<Vec<_>>();
+        log::debug!("Topic: {topic:?}",);
+
+        match topic.as_slice() {
+            [""] => Err(ParseError::Empty),
+            [channel] => Ok(ParsedPublishTopic {
+                channel,
+                device: None,
+                properties: vec![],
+            }),
+            [channel, as_device] => Ok(ParsedPublishTopic {
+                channel,
+                device: Some(as_device),
+                properties: vec![],
+            }),
+            _ => Err(ParseError::Syntax),
+        }
+    }
+}
+
+impl SubscribeTopicParser for DrogueV1 {
+    fn parse_subscribe<'a>(&self, path: &'a str) -> Result<ParsedSubscribeTopic<'a>, ParseError> {
+        match path.split('/').collect::<Vec<_>>().as_slice() {
+            // subscribe to commands for all proxied devices and ourself
+            ["command", "inbox", "#"] | ["command", "inbox", "+", "#"] => {
+                Ok(ParsedSubscribeTopic {
+                    filter: SubscribeFilter {
+                        device: DeviceFilter::Wildcard,
+                        command: None,
+                    },
+                    encoder: SubscriptionTopicEncoder::new(DefaultCommandTopicEncoder(false)),
+                })
+            }
+            // subscribe to commands directly for us
+            ["command", "inbox", "", "#"] => Ok(ParsedSubscribeTopic {
+                filter: SubscribeFilter {
+                    device: DeviceFilter::Device,
+                    command: None,
+                },
+                encoder: SubscriptionTopicEncoder::new(DefaultCommandTopicEncoder(false)),
+            }),
+            // subscribe to commands for a specific device
+            ["command", "inbox", device, "#"] => Ok(ParsedSubscribeTopic {
+                filter: SubscribeFilter {
+                    device: DeviceFilter::ProxiedDevice(device),
+                    command: None,
+                },
+                encoder: SubscriptionTopicEncoder::new(DefaultCommandTopicEncoder(true)),
+            }),
+            _ => Err(ParseError::Syntax),
+        }
+    }
+}
+
+/// The default (Drogue V1) encoder, which expects the command inbox pattern.
+#[derive(Debug)]
+pub struct DefaultCommandTopicEncoder(pub bool);
+
+impl TopicEncoder for DefaultCommandTopicEncoder {
+    fn encode_command_topic(&self, command: &Command) -> String {
+        // if we are forced to report the device part, or the device id is not equal to the
+        // connected device, then we need to add it.
+        if self.0 || command.address.gateway_id != command.address.device_id {
+            format!(
+                "command/inbox/{}/{}",
+                command.address.device_id, command.command
+            )
+        } else {
+            format!("command/inbox//{}", command.command)
+        }
+    }
+}

--- a/mqtt-endpoint/src/service/session/dialect/encoder.rs
+++ b/mqtt-endpoint/src/service/session/dialect/encoder.rs
@@ -1,0 +1,62 @@
+use drogue_cloud_endpoint_common::command::Command;
+use std::fmt::Debug;
+use std::ops::Deref;
+
+/// A structure boxing a dynamic [`TopicEncoder`] instance.
+#[derive(Debug)]
+pub struct SubscriptionTopicEncoder(Box<dyn TopicEncoder>);
+
+impl Deref for SubscriptionTopicEncoder {
+    type Target = dyn TopicEncoder;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}
+
+impl SubscriptionTopicEncoder {
+    pub fn new<T>(encoder: T) -> Self
+    where
+        T: TopicEncoder + 'static,
+    {
+        Self(Box::new(encoder))
+    }
+}
+
+/// An encoder, from commands to topic names.
+///
+/// This carries over the information from the subscription request, to the encoding of topic names
+/// for received commands.
+pub trait TopicEncoder: Debug {
+    /// Encode a topic from a command, requested originally by a SUB request
+    fn encode_command_topic(&self, command: &Command) -> String;
+}
+
+/// The default (Drogue V1) encoder, which expects the command inbox pattern.
+#[derive(Debug)]
+pub struct DefaultCommandTopicEncoder(pub bool);
+
+impl TopicEncoder for DefaultCommandTopicEncoder {
+    fn encode_command_topic(&self, command: &Command) -> String {
+        // if we are forced to report the device part, or the device id is not equal to the
+        // connected device, then we need to add it.
+        if self.0 || command.address.gateway_id != command.address.device_id {
+            format!(
+                "command/inbox/{}/{}",
+                command.address.device_id, command.command
+            )
+        } else {
+            format!("command/inbox//{}", command.command)
+        }
+    }
+}
+
+/// An encoder which uses the plain command name as topic.
+#[derive(Debug)]
+pub struct PlainTopicEncoder;
+
+impl TopicEncoder for PlainTopicEncoder {
+    fn encode_command_topic(&self, command: &Command) -> String {
+        command.command.clone()
+    }
+}

--- a/mqtt-endpoint/src/service/session/dialect/encoder.rs
+++ b/mqtt-endpoint/src/service/session/dialect/encoder.rs
@@ -32,25 +32,6 @@ pub trait TopicEncoder: Debug {
     fn encode_command_topic(&self, command: &Command) -> String;
 }
 
-/// The default (Drogue V1) encoder, which expects the command inbox pattern.
-#[derive(Debug)]
-pub struct DefaultCommandTopicEncoder(pub bool);
-
-impl TopicEncoder for DefaultCommandTopicEncoder {
-    fn encode_command_topic(&self, command: &Command) -> String {
-        // if we are forced to report the device part, or the device id is not equal to the
-        // connected device, then we need to add it.
-        if self.0 || command.address.gateway_id != command.address.device_id {
-            format!(
-                "command/inbox/{}/{}",
-                command.address.device_id, command.command
-            )
-        } else {
-            format!("command/inbox//{}", command.command)
-        }
-    }
-}
-
 /// An encoder which uses the plain command name as topic.
 #[derive(Debug)]
 pub struct PlainTopicEncoder;

--- a/mqtt-endpoint/src/service/session/dialect/plain.rs
+++ b/mqtt-endpoint/src/service/session/dialect/plain.rs
@@ -1,0 +1,46 @@
+use super::*;
+
+/// Plain topic dialect.
+pub struct PlainTopic {
+    pub device_prefix: bool,
+}
+
+impl PublishTopicParser for PlainTopic {
+    fn parse_publish<'a>(&self, path: &'a str) -> Result<ParsedPublishTopic<'a>, ParseError> {
+        match self.device_prefix {
+            true => {
+                // Plain topic (with device prefix). Strip the device, and then just take the complete path
+
+                let topic = path.split_once('/');
+                log::debug!("Topic: {topic:?}",);
+
+                match topic {
+                    // No topic at all
+                    None if path.is_empty() => Err(ParseError::Empty),
+                    None => Err(ParseError::Syntax),
+                    Some(("", path)) => Ok(ParsedPublishTopic {
+                        channel: path,
+                        device: None,
+                        properties: vec![],
+                    }),
+                    Some((device, path)) => Ok(ParsedPublishTopic {
+                        channel: path,
+                        device: Some(device),
+                        properties: vec![],
+                    }),
+                }
+            }
+            false => {
+                // Plain topic, just take the complete path
+                match path {
+                    "" => Err(ParseError::Empty),
+                    path => Ok(ParsedPublishTopic {
+                        channel: path,
+                        device: None,
+                        properties: vec![],
+                    }),
+                }
+            }
+        }
+    }
+}

--- a/mqtt-endpoint/src/service/session/dialect/wot.rs
+++ b/mqtt-endpoint/src/service/session/dialect/wot.rs
@@ -1,5 +1,52 @@
+use super::*;
+
 use crate::service::session::dialect::TopicEncoder;
 use drogue_cloud_endpoint_common::command::Command;
+
+/// Web of Things dialect.
+pub struct WebOfThings {
+    pub node_wot_bug: bool,
+}
+
+impl PublishTopicParser for WebOfThings {
+    fn parse_publish<'a>(&self, path: &'a str) -> Result<ParsedPublishTopic<'a>, ParseError> {
+        let topic = path.split_once('/');
+        log::debug!("Topic: {topic:?}",);
+
+        match topic {
+            // No topic at all
+            None if path.is_empty() => Err(ParseError::Empty),
+            None => Ok(ParsedPublishTopic {
+                channel: "",
+                device: Some(path),
+                properties: vec![],
+            }),
+            Some(("", _)) => Err(ParseError::Syntax),
+            Some((device, path)) => Ok(ParsedPublishTopic {
+                channel: path,
+                device: Some(device),
+                properties: vec![],
+            }),
+        }
+    }
+}
+
+impl SubscribeTopicParser for WebOfThings {
+    fn parse_subscribe<'a>(&self, path: &'a str) -> Result<ParsedSubscribeTopic<'a>, ParseError> {
+        match path.split_once('/') {
+            Some((device, filter)) => Ok(ParsedSubscribeTopic {
+                filter: SubscribeFilter {
+                    device: DeviceFilter::ProxiedDevice(device),
+                    command: Some(filter),
+                },
+                encoder: SubscriptionTopicEncoder::new(WoTCommandTopicEncoder {
+                    node_wot_bug: self.node_wot_bug,
+                }),
+            }),
+            _ => Err(ParseError::Syntax),
+        }
+    }
+}
 
 #[derive(Debug)]
 pub struct WoTCommandTopicEncoder {

--- a/mqtt-endpoint/src/service/session/dialect/wot.rs
+++ b/mqtt-endpoint/src/service/session/dialect/wot.rs
@@ -4,6 +4,8 @@ use crate::service::session::dialect::TopicEncoder;
 use drogue_cloud_endpoint_common::command::Command;
 
 /// Web of Things dialect.
+///
+/// NOTE: This is experimental.
 pub struct WebOfThings {
     pub node_wot_bug: bool,
 }

--- a/mqtt-endpoint/src/service/session/mod.rs
+++ b/mqtt-endpoint/src/service/session/mod.rs
@@ -1,5 +1,5 @@
 mod cache;
-mod dialect;
+pub mod dialect;
 mod disconnect;
 mod inbox;
 
@@ -7,9 +7,7 @@ use self::disconnect::*;
 use crate::{
     auth::DeviceAuthenticator,
     config::EndpointConfig,
-    service::session::dialect::{
-        DefaultTopicParser, ParsedSubscribeTopic, SubscriptionTopicEncoder,
-    },
+    service::session::dialect::{Dialect, ParsedSubscribeTopic, SubscriptionTopicEncoder},
     CONNECTIONS_COUNTER,
 };
 use async_trait::async_trait;
@@ -57,7 +55,7 @@ pub struct Session {
     sender: DownstreamSender,
     application: registry::v1::Application,
     device: Arc<registry::v1::Device>,
-    dialect: registry::v1::MqttDialect,
+    dialect: Dialect,
     commands: Commands,
     auth: DeviceAuthenticator,
     sink: Sink,
@@ -75,7 +73,7 @@ impl Session {
         sender: DownstreamSender,
         sink: Sink,
         application: registry::v1::Application,
-        dialect: registry::v1::MqttDialect,
+        dialect: Dialect,
         device: registry::v1::Device,
         commands: Commands,
         state: State,

--- a/mqtt-integration/src/service/session.rs
+++ b/mqtt-integration/src/service/session.rs
@@ -254,7 +254,7 @@ impl Session {
 #[async_trait(?Send)]
 impl mqtt::Session for Session {
     async fn publish(&self, publish: Publish<'_>) -> Result<(), PublishError> {
-        let topic = publish.topic().path().split('/').collect::<Vec<_>>();
+        let topic = publish.topic().path().splitn(4, '/').collect::<Vec<_>>();
 
         if topic.len() != 4 || !topic[0].eq_ignore_ascii_case("command") {
             log::info!("Invalid topic name {:?}", topic);


### PR DESCRIPTION
This adds some internal infrastructure for adding more MQTT endpoint dialects. Also doing some example work with:

* Web of Things
* Cumulocity
* Azure IoT