### PR TITLE
More granularity in roles and permissions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,6 +1416,7 @@ checksum = "03d8c417d7a8cb362e0c37e5d815f5eb7c37f79ff93707329d5a194e42e54ca0"
 [[package]]
 name = "drogue-bazaar"
 version = "0.3.0"
+source = "git+https://github.com/drogue-iot/drogue-bazaar?rev=8c6f6f6456a18fd8ab41ca2a64b45b154a94f4aa#8c6f6f6456a18fd8ab41ca2a64b45b154a94f4aa"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -1464,6 +1465,7 @@ dependencies = [
 [[package]]
 name = "drogue-client"
 version = "0.12.0"
+source = "git+https://github.com/drogue-iot/drogue-client?rev=fdebb42a6cbaa872a779e892fefe0f687b34fa4b#fdebb42a6cbaa872a779e892fefe0f687b34fa4b"
 dependencies = [
  "async-trait",
  "base64 0.13.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,7 +1416,6 @@ checksum = "03d8c417d7a8cb362e0c37e5d815f5eb7c37f79ff93707329d5a194e42e54ca0"
 [[package]]
 name = "drogue-bazaar"
 version = "0.3.0"
-source = "git+https://github.com/drogue-iot/drogue-bazaar?rev=8c6f6f6456a18fd8ab41ca2a64b45b154a94f4aa#8c6f6f6456a18fd8ab41ca2a64b45b154a94f4aa"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -1465,7 +1464,6 @@ dependencies = [
 [[package]]
 name = "drogue-client"
 version = "0.12.0"
-source = "git+https://github.com/drogue-iot/drogue-client?rev=fdebb42a6cbaa872a779e892fefe0f687b34fa4b#fdebb42a6cbaa872a779e892fefe0f687b34fa4b"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -1511,6 +1509,7 @@ dependencies = [
  "futures",
  "futures-core",
  "futures-util",
+ "indexmap",
  "log",
  "native-tls",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,7 +1416,6 @@ checksum = "03d8c417d7a8cb362e0c37e5d815f5eb7c37f79ff93707329d5a194e42e54ca0"
 [[package]]
 name = "drogue-bazaar"
 version = "0.3.0"
-source = "git+https://github.com/drogue-iot/drogue-bazaar?rev=d19ad32f200938aeb5d7081ee3385ee40c5ae0ff#d19ad32f200938aeb5d7081ee3385ee40c5ae0ff"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -1465,7 +1464,6 @@ dependencies = [
 [[package]]
 name = "drogue-client"
 version = "0.12.0"
-source = "git+https://github.com/drogue-iot/drogue-client?rev=798c968f0a63a0debcff9965c66b361e85946458#798c968f0a63a0debcff9965c66b361e85946458"
 dependencies = [
  "async-trait",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,11 +45,11 @@ testcontainers = { git = "https://github.com/testcontainers/testcontainers-rs", 
 #reqwest = { git = "https://github.com/ctron/reqwest", branch = "feature/basic_auth_wasm_1" }
 #drogue-ttn = { git = "https://github.com/drogue-iot/drogue-ttn", rev = "cf0338a344309815f0f05e0d7d76acb712445175" } # FIXME: awaiting release
 
-drogue-bazaar = { git = "https://github.com/drogue-iot/drogue-bazaar", rev = "8c6f6f6456a18fd8ab41ca2a64b45b154a94f4aa" } # FIXME: awaiting release 0.4.0
-#drogue-bazaar = { path = "../../drogue-bazaar" }
+#drogue-bazaar = { git = "https://github.com/drogue-iot/drogue-bazaar", rev = "8c6f6f6456a18fd8ab41ca2a64b45b154a94f4aa" } # FIXME: awaiting release 0.4.0
+drogue-bazaar = { path = "../drogue-bazaar" }
 
-drogue-client = { git = "https://github.com/drogue-iot/drogue-client", rev = "fdebb42a6cbaa872a779e892fefe0f687b34fa4b" } # FIXME: awaiting release 0.12.0
-#drogue-client = { path = "../../drogue-client" }
+#drogue-client = { git = "https://github.com/drogue-iot/drogue-client", rev = "fdebb42a6cbaa872a779e892fefe0f687b34fa4b" } # FIXME: awaiting release 0.12.0
+drogue-client = { path = "../drogue-client" }
 
 operator-framework = { git = "https://github.com/ctron/operator-framework", rev = "8366506a3ed44b638f899dcce4a82ac32fcaff9e" } # FIXME: awaiting release 0.7.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,11 +45,11 @@ testcontainers = { git = "https://github.com/testcontainers/testcontainers-rs", 
 #reqwest = { git = "https://github.com/ctron/reqwest", branch = "feature/basic_auth_wasm_1" }
 #drogue-ttn = { git = "https://github.com/drogue-iot/drogue-ttn", rev = "cf0338a344309815f0f05e0d7d76acb712445175" } # FIXME: awaiting release
 
-#drogue-bazaar = { git = "https://github.com/drogue-iot/drogue-bazaar", rev = "e74ee3f01a0ab1cc55825abefb0f12b82eee67d9" } # FIXME: awaiting release 0.3.0
-drogue-bazaar = { path = "../drogue-bazaar" }
+drogue-bazaar = { git = "https://github.com/drogue-iot/drogue-bazaar", rev = "8c6f6f6456a18fd8ab41ca2a64b45b154a94f4aa" } # FIXME: awaiting release 0.4.0
+#drogue-bazaar = { path = "../../drogue-bazaar" }
 
-#drogue-client = { git = "https://github.com/drogue-iot/drogue-client", rev = "78aaf1b0ab7524f428efec5a9de75a1242701951" } # FIXME: awaiting release 0.11.0
-drogue-client = { path = "../drogue-client" }
+drogue-client = { git = "https://github.com/drogue-iot/drogue-client", rev = "fdebb42a6cbaa872a779e892fefe0f687b34fa4b" } # FIXME: awaiting release 0.12.0
+#drogue-client = { path = "../../drogue-client" }
 
 operator-framework = { git = "https://github.com/ctron/operator-framework", rev = "8366506a3ed44b638f899dcce4a82ac32fcaff9e" } # FIXME: awaiting release 0.7.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,8 @@ testcontainers = { git = "https://github.com/testcontainers/testcontainers-rs", 
 drogue-bazaar = { git = "https://github.com/drogue-iot/drogue-bazaar", rev = "d19ad32f200938aeb5d7081ee3385ee40c5ae0ff" } # FIXME: awaiting release 0.4.0
 #drogue-bazaar = { path = "../drogue-bazaar" }
 
-drogue-client = { git = "https://github.com/drogue-iot/drogue-client", rev = "798c968f0a63a0debcff9965c66b361e85946458" } # FIXME: awaiting release 0.12.0
-#drogue-client = { path = "../drogue-client" }
+#drogue-client = { git = "https://github.com/drogue-iot/drogue-client", rev = "78aaf1b0ab7524f428efec5a9de75a1242701951" } # FIXME: awaiting release 0.11.0
+drogue-client = { path = "../drogue-client" }
 
 operator-framework = { git = "https://github.com/ctron/operator-framework", rev = "8366506a3ed44b638f899dcce4a82ac32fcaff9e" } # FIXME: awaiting release 0.7.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,8 @@ testcontainers = { git = "https://github.com/testcontainers/testcontainers-rs", 
 #reqwest = { git = "https://github.com/ctron/reqwest", branch = "feature/basic_auth_wasm_1" }
 #drogue-ttn = { git = "https://github.com/drogue-iot/drogue-ttn", rev = "cf0338a344309815f0f05e0d7d76acb712445175" } # FIXME: awaiting release
 
-drogue-bazaar = { git = "https://github.com/drogue-iot/drogue-bazaar", rev = "d19ad32f200938aeb5d7081ee3385ee40c5ae0ff" } # FIXME: awaiting release 0.4.0
-#drogue-bazaar = { path = "../drogue-bazaar" }
+#drogue-bazaar = { git = "https://github.com/drogue-iot/drogue-bazaar", rev = "e74ee3f01a0ab1cc55825abefb0f12b82eee67d9" } # FIXME: awaiting release 0.3.0
+drogue-bazaar = { path = "../drogue-bazaar" }
 
 #drogue-client = { git = "https://github.com/drogue-iot/drogue-client", rev = "78aaf1b0ab7524f428efec5a9de75a1242701951" } # FIXME: awaiting release 0.11.0
 drogue-client = { path = "../drogue-client" }

--- a/access-token-service/Cargo.toml
+++ b/access-token-service/Cargo.toml
@@ -19,6 +19,7 @@ env_logger = "0.9"
 futures = "0.3"
 futures-core = "0.3"
 futures-util = "0.3"
+indexmap = { version = "1", features = ["serde"] }
 log = "0.4"
 native-tls = "0.2"
 rand = "0.8"

--- a/access-token-service/src/authz.rs
+++ b/access-token-service/src/authz.rs
@@ -1,9 +1,38 @@
-// an actix middlware that verifies access tokens permissions
+use async_trait::async_trait;
+use drogue_client::user::v1::authz::{Outcome, TokenPermission};
+use drogue_cloud_service_api::webapp::http::Method;
+use drogue_cloud_service_common::actix_auth::authorization::{Authorizer, Context};
+use drogue_cloud_service_common::auth::AuthError;
 
-// if let Some(claims) in UserInfo {
-//    verify them
-//    for the current operation
-//
-//    For the create permission, verify the payload don't contains additionnal claims
-//        -> for that make a claims struct with helpers methods
-// }
+#[derive(Clone, Debug)]
+pub struct TokenOperationAuthorizer;
+
+#[async_trait(?Send)]
+impl Authorizer for TokenOperationAuthorizer {
+    async fn authorize(&self, context: &Context<'_>) -> Result<Option<Outcome>, AuthError> {
+        let outcome = if let Some(claims) = context.identity.token_claims() {
+            // Middlewares cannot be registered to routes so we have to determine what type of permission
+            // to apply here
+            let permission_required = match *context.request.method() {
+                Method::GET => TokenPermission::List,
+                Method::POST => TokenPermission::Create,
+                Method::DELETE => TokenPermission::Delete,
+                // this should be unreachable if actix does its job
+                _ => {
+                    return Err(AuthError::InvalidRequest(
+                        "Method not defined in the API. This should never happen.".to_string(),
+                    ))
+                }
+            };
+
+            if claims.tokens.contains(&permission_required) {
+                Outcome::Allow
+            } else {
+                Outcome::Deny
+            }
+        } else {
+            Outcome::Allow
+        };
+        Ok(Some(outcome))
+    }
+}

--- a/access-token-service/src/authz.rs
+++ b/access-token-service/src/authz.rs
@@ -1,0 +1,9 @@
+// an actix middlware that verifies access tokens permissions
+
+// if let Some(claims) in UserInfo {
+//    verify them
+//    for the current operation
+//
+//    For the create permission, verify the payload don't contains additionnal claims
+//        -> for that make a claims struct with helpers methods
+// }

--- a/access-token-service/src/endpoints.rs
+++ b/access-token-service/src/endpoints.rs
@@ -22,7 +22,7 @@ impl<S: AccessTokenService> Deref for WebData<S> {
 pub async fn create<S>(
     user: UserInformation,
     service: web::Data<WebData<S>>,
-    opts: web::Query<AccessTokenCreationOptions>,
+    opts: web::Json<AccessTokenCreationOptions>,
 ) -> Result<HttpResponse, actix_web::Error>
 where
     S: AccessTokenService + 'static,

--- a/access-token-service/src/endpoints.rs
+++ b/access-token-service/src/endpoints.rs
@@ -1,4 +1,5 @@
 use crate::service::AccessTokenService;
+use drogue_client::registry::v1::Client;
 use drogue_client::user::v1::authn::{AuthenticationRequest, AuthenticationResponse, Outcome};
 use drogue_cloud_service_api::{
     auth::user::UserInformation,
@@ -22,12 +23,13 @@ impl<S: AccessTokenService> Deref for WebData<S> {
 pub async fn create<S>(
     user: UserInformation,
     service: web::Data<WebData<S>>,
+    registry: web::Data<Client>,
     opts: web::Json<AccessTokenCreationOptions>,
 ) -> Result<HttpResponse, actix_web::Error>
 where
     S: AccessTokenService + 'static,
 {
-    let result = match service.create(&user, opts.0).await {
+    let result = match service.create(&user, opts.0, &registry.into_inner()).await {
         Ok(key) => Ok(HttpResponse::Ok().json(key)),
         Err(e) => Err(e.into()),
     };

--- a/access-token-service/src/lib.rs
+++ b/access-token-service/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod authz;
 pub mod endpoints;
 pub mod mock;
 mod rng;

--- a/access-token-service/src/mock.rs
+++ b/access-token-service/src/mock.rs
@@ -29,6 +29,7 @@ impl AccessTokenService for MockAccessTokenService {
         &self,
         _: &UserInformation,
         _: AccessTokenCreationOptions,
+        _: &drogue_client::registry::v1::Client,
     ) -> Result<CreatedAccessToken, Self::Error> {
         todo!()
     }

--- a/access-token-service/src/mock.rs
+++ b/access-token-service/src/mock.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use drogue_cloud_service_api::webapp::ResponseError;
 use drogue_cloud_service_api::{
     auth::user::{UserDetails, UserInformation},
-    token::{AccessToken, AccessTokenCreated, AccessTokenCreationOptions},
+    token::{AccessToken, AccessTokenCreationOptions, CreatedAccessToken},
 };
 use std::fmt::Formatter;
 
@@ -29,7 +29,7 @@ impl AccessTokenService for MockAccessTokenService {
         &self,
         _: &UserInformation,
         _: AccessTokenCreationOptions,
-    ) -> Result<AccessTokenCreated, Self::Error> {
+    ) -> Result<CreatedAccessToken, Self::Error> {
         todo!()
     }
 

--- a/access-token-service/src/rng.rs
+++ b/access-token-service/src/rng.rs
@@ -1,4 +1,4 @@
-use drogue_cloud_service_api::token::AccessTokenCreated;
+use drogue_cloud_service_api::token::CreatedAccessToken;
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use sha3::Digest;
 
@@ -32,7 +32,7 @@ pub fn hash_token(token: &str) -> String {
     format!("{:x}", sha3::Sha3_512::digest(token.as_bytes()))
 }
 
-fn serialize_token(prefix: String, key: String) -> (AccessTokenCreated, String) {
+fn serialize_token(prefix: String, key: String) -> (CreatedAccessToken, String) {
     let token = format!("{}_{}", prefix, key);
 
     let crc = crc::crc32::checksum_ieee(token.as_bytes());
@@ -42,13 +42,13 @@ fn serialize_token(prefix: String, key: String) -> (AccessTokenCreated, String) 
 
     let hashed = hash_token(&token);
 
-    (AccessTokenCreated { prefix, token }, hashed)
+    (CreatedAccessToken { prefix, token }, hashed)
 }
 
 /// Create a new (random) AccessToken.
 ///
 /// It will return a tuple, consisting of the actual Access Token as well as the hashed version.
-pub fn generate_access_token() -> (AccessTokenCreated, String) {
+pub fn generate_access_token() -> (CreatedAccessToken, String) {
     let prefix = generate_prefix();
     let raw_key = generate_key();
 

--- a/command-endpoint/src/lib.rs
+++ b/command-endpoint/src/lib.rs
@@ -1,6 +1,7 @@
 mod v1alpha1;
 
 use actix_web::{web, HttpResponse, Responder};
+use drogue_client::user::v1::authz::ApplicationPermission;
 use drogue_client::{registry, user::v1::authz::Permission};
 use drogue_cloud_endpoint_common::{
     sender::{ExternalClientPoolConfig, UpstreamSender},
@@ -94,7 +95,7 @@ pub async fn configurator(
                     web::scope("/api/command/v1alpha1/apps/{application}/devices/{deviceId}")
                         .wrap(ApplicationAuthorizer::wrapping(
                             user_auth.clone(),
-                            Permission::Read,
+                            Permission::App(ApplicationPermission::Command),
                         ))
                         .wrap(AuthN::from((
                             authenticator.clone(),

--- a/console-backend/api/index.yaml
+++ b/console-backend/api/index.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   title: Drogue Cloud API
-  version: "0.11"
+  version: "0.12"
   contact:
     url: https://drogue.io
   description: |
@@ -103,6 +103,13 @@ paths:
           description: A description to attach to the token entry.
           schema:
             type: string
+      requestBody:
+        required: false
+        description: Optional claims to limit the token permissions.
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/PersonalAccessToken'
       responses:
         "200":
           description: A new access token was created.
@@ -233,8 +240,6 @@ paths:
         required: true
         content:
           application/json:
-            schema:
-              $ref: '#/components/schema/Patch'
             example:
               [
                 { "op": "replace", "path": "/baz", "value": "boo" },
@@ -342,8 +347,6 @@ paths:
         required: true
         content:
           application/json:
-            schema:
-              $ref: '#/components/schemas/Patch'
             example:
               [
                 { "op": "replace", "path": "/baz", "value": "boo" },
@@ -816,11 +819,11 @@ components:
         resourceVersion: ced63698-a0da-11eb-97e8-d45d6455d2cc
         members:
           d84eb308-a0da-11eb-9e90-d45d6455d2cc:
-            role: admin
+            roles: [admin]
           03e32c1a-a0db-11eb-9e9b-d45d6455d2cc:
-            role: manager
+            roles: [manager]
           0a111dfe-a0db-11eb-a953-d45d6455d2cc:
-            role: reader
+            roles: [publisher, subscriber]
 
     MemberEntry:
       type: object
@@ -829,11 +832,67 @@ components:
         - role
       properties:
         role:
+          $ref:
+            '#/components/schemas/Roles'
+    Roles:
+      type: array
+      enum:
+        - reader
+        - manager
+        - admin
+        - publisher
+        - subscriber
+
+    PersonalAccessToken:
+      description: An access token to access drogue-cloud
+      type: object
+      additionalProperties: false
+      properties:
+        description:
           type: string
-          enum:
-            - reader
-            - writer
-            - admin
+          description: The token description
+          required: false
+        claims:
+          required: false
+          description: |
+            The permission claims for the token. If not set, the token will have the same permissions 
+            as the owner. If set but empty, the token will have no permissions.
+          type: object
+          properties:
+            create:
+              type: boolean
+              description: allow to create applications.
+              default: false
+              required: false
+            tokens:
+              type: array
+              description: Access token permissions.
+              items:
+                enum:
+                  - create
+                  - read
+                  - delete
+            applications:
+              type: object
+              description: The applications to grant permission on
+              additionalProperties:
+                  $ref: '#/components/schemas/Roles'
+      example:
+        description: my not so restricted access token
+        claims:
+          create: false
+          applications:
+            - example-app:
+                - admin
+            - other-app:
+                - publish
+                - subscribe
+            - myapp:
+                - read
+          tokens:
+            - create
+            - read
+
 
     ApplicationSpec:
       type: object

--- a/console-backend/api/index.yaml
+++ b/console-backend/api/index.yaml
@@ -360,30 +360,6 @@ paths:
   # ## Admin
   #
 
-  /api/admin/v1alpha1/user/whoami:
-    get:
-      tags:
-        - User administration
-      description: Get information about the current user.
-      responses:
-        200:
-          description: Information about the current user.
-          content:
-            'application/json':
-              schema:
-                type: object
-                properties:
-                  id:
-                    type: string
-                    description: |
-                      The ID of the current user.
-
-                      NOTE: This ID may be different to the name of the user.
-                required:
-                  - id
-        403:
-          description: In case the user is not logged in.
-
   /api/admin/v1alpha1/apps/{application}/transfer-ownership:
     parameters:
       - $ref: '#/components/parameters/ApplicationName'

--- a/console-backend/src/admin.rs
+++ b/console-backend/src/admin.rs
@@ -1,9 +1,0 @@
-use actix_web::HttpResponse;
-use drogue_cloud_service_api::auth::user::UserInformation;
-use serde_json::json;
-
-pub async fn whoami(user: UserInformation) -> Result<HttpResponse, actix_web::Error> {
-    Ok(HttpResponse::Ok().json(json!({
-        "id": user.user_id(),
-    })))
-}

--- a/console-backend/src/info.rs
+++ b/console-backend/src/info.rs
@@ -21,7 +21,8 @@ impl DemoFetcher {
     }
 }
 
-pub async fn get_info(
+#[get("/drogue-endpoints")]
+pub async fn get_public_endpoints(
     endpoints: web::Data<Endpoints>,
     demos: web::Data<DemoFetcher>,
 ) -> impl Responder {
@@ -30,11 +31,6 @@ pub async fn get_info(
         demos: demos.get_ref().get_demos().await,
     };
     HttpResponse::Ok().json(info)
-}
-
-#[get("/drogue-endpoints")]
-pub async fn get_public_endpoints(endpoints: web::Data<Endpoints>) -> impl Responder {
-    HttpResponse::Ok().json(endpoints)
 }
 
 #[get("/drogue-version")]

--- a/console-backend/src/lib.rs
+++ b/console-backend/src/lib.rs
@@ -1,4 +1,3 @@
-mod admin;
 mod api;
 mod demos;
 mod info;
@@ -222,19 +221,7 @@ pub async fn configurator(
                             >),
                         )),
                 )
-                .service(
-                    web::scope("/api/admin/v1alpha1")
-                        .wrap(auth.clone())
-                        .service(web::resource("/user/whoami").route(web::get().to(admin::whoami))),
-                )
                 // everything from here on is unauthenticated or not using the middleware
-                .service(
-                    web::scope("/api/console/v1alpha1").service(
-                        web::resource("/info")
-                            .wrap(auth)
-                            .route(web::get().to(info::get_info)),
-                    ),
-                )
                 .service(index)
                 .service(
                     web::scope("/.well-known")

--- a/console-backend/src/lib.rs
+++ b/console-backend/src/lib.rs
@@ -9,11 +9,13 @@ use actix_web::{
 };
 use anyhow::Context;
 use drogue_client::{registry, user};
+use drogue_cloud_access_token_service::authz::TokenOperationAuthorizer;
 use drogue_cloud_access_token_service::{endpoints as keys, service::KeycloakAccessTokenService};
 use drogue_cloud_service_api::{
     endpoints::Endpoints, health::HealthChecked, kafka::KafkaClientConfig,
     webapp::web::ServiceConfig,
 };
+use drogue_cloud_service_common::actix_auth::authorization::AuthZ;
 use drogue_cloud_service_common::{
     actix::http::{CorsConfig, HttpBuilder, HttpConfig},
     actix_auth::authentication::AuthN,
@@ -205,6 +207,7 @@ pub async fn configurator(
             app.app_data(web::Data::new(endpoints.clone()))
                 .service(
                     web::scope("/api/tokens/v1alpha1")
+                        .wrap(AuthZ::new(TokenOperationAuthorizer {}))
                         .wrap(auth.clone())
                         .service(
                             web::resource("")

--- a/console-frontend/Cargo.lock
+++ b/console-frontend/Cargo.lock
@@ -538,7 +538,7 @@ checksum = "03d8c417d7a8cb362e0c37e5d815f5eb7c37f79ff93707329d5a194e42e54ca0"
 [[package]]
 name = "drogue-bazaar"
 version = "0.3.0"
-source = "git+https://github.com/drogue-iot/drogue-bazaar?rev=d19ad32f200938aeb5d7081ee3385ee40c5ae0ff#d19ad32f200938aeb5d7081ee3385ee40c5ae0ff"
+source = "git+https://github.com/drogue-iot/drogue-bazaar?rev=8c6f6f6456a18fd8ab41ca2a64b45b154a94f4aa#8c6f6f6456a18fd8ab41ca2a64b45b154a94f4aa"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -567,7 +567,7 @@ dependencies = [
 [[package]]
 name = "drogue-client"
 version = "0.12.0"
-source = "git+https://github.com/drogue-iot/drogue-client?rev=798c968f0a63a0debcff9965c66b361e85946458#798c968f0a63a0debcff9965c66b361e85946458"
+source = "git+https://github.com/drogue-iot/drogue-client?rev=fdebb42a6cbaa872a779e892fefe0f687b34fa4b#fdebb42a6cbaa872a779e892fefe0f687b34fa4b"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -1983,9 +1983,8 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "patternfly-yew"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccfe177a94ab0fe2db19bc3b86389555b4fdb6acad44443fdeddf6f3f32b3630"
+version = "0.2.3"
+source = "git+https://github.com/ctron/patternfly-yew?rev=331782836f0ed67bc6ab41ef71497c970176e9d4#331782836f0ed67bc6ab41ef71497c970176e9d4"
 dependencies = [
  "chrono",
  "gloo-events",

--- a/console-frontend/Cargo.lock
+++ b/console-frontend/Cargo.lock
@@ -1984,7 +1984,6 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 [[package]]
 name = "patternfly-yew"
 version = "0.2.3"
-source = "git+https://github.com/ctron/patternfly-yew?rev=331782836f0ed67bc6ab41ef71497c970176e9d4#331782836f0ed67bc6ab41ef71497c970176e9d4"
 dependencies = [
  "chrono",
  "gloo-events",

--- a/console-frontend/Cargo.toml
+++ b/console-frontend/Cargo.toml
@@ -29,7 +29,7 @@ log = "0.4"
 md5 = "0.7"
 monaco = { version = "0.3", features = ["yew-components"] }
 once_cell = "1"
-patternfly-yew = "0.2.0"
+patternfly-yew = "0.2.3"
 percent-encoding = "2.1"
 pretty-hex = "0.3"
 reqwest = "0.11"
@@ -92,13 +92,13 @@ opt-level = 's'
 lto = true
 
 [patch.crates-io]
-#patternfly-yew = { git = "https://github.com/ctron/patternfly-yew", rev = "32c809e030ca9ec5f7785dc7e0a78d574b9830f8" } # FIXME: awaiting release
-#patternfly-yew = { path = "../../patternfly-yew" }
+patternfly-yew = { git = "https://github.com/ctron/patternfly-yew", rev = "331782836f0ed67bc6ab41ef71497c970176e9d4" } # FIXME: awaiting release
+#patternfly-yew = { path = "../../../patternfly-yew" }
 
-drogue-client = { git = "https://github.com/drogue-iot/drogue-client", rev = "798c968f0a63a0debcff9965c66b361e85946458" } # FIXME: awaiting release 0.12.0
+drogue-client = { git = "https://github.com/drogue-iot/drogue-client", rev = "fdebb42a6cbaa872a779e892fefe0f687b34fa4b" } # FIXME: awaiting release 0.12.0
 #drogue-client = { path = "../../drogue-client" }
 
-drogue-bazaar = { git = "https://github.com/drogue-iot/drogue-bazaar", rev = "d19ad32f200938aeb5d7081ee3385ee40c5ae0ff" } # FIXME: awaiting release 0.4.0
+drogue-bazaar = { git = "https://github.com/drogue-iot/drogue-bazaar", rev = "8c6f6f6456a18fd8ab41ca2a64b45b154a94f4aa" } # FIXME: awaiting release 0.4.0
 #drogue-bazaar = { path = "../../drogue-bazaar" }
 
 #monaco = { git = "https://github.com/siku2/rust-monaco", rev = "cb20108c317976ba8c3d05b581a84efd394c3dbe" } # FIXME: awaiting release

--- a/console-frontend/Cargo.toml
+++ b/console-frontend/Cargo.toml
@@ -92,8 +92,8 @@ opt-level = 's'
 lto = true
 
 [patch.crates-io]
-patternfly-yew = { git = "https://github.com/ctron/patternfly-yew", rev = "331782836f0ed67bc6ab41ef71497c970176e9d4" } # FIXME: awaiting release
-#patternfly-yew = { path = "../../../patternfly-yew" }
+#patternfly-yew = { git = "https://github.com/ctron/patternfly-yew", rev = "331782836f0ed67bc6ab41ef71497c970176e9d4" } # FIXME: awaiting release
+patternfly-yew = { path = "../../../patternfly-yew" }
 
 drogue-client = { git = "https://github.com/drogue-iot/drogue-client", rev = "fdebb42a6cbaa872a779e892fefe0f687b34fa4b" } # FIXME: awaiting release 0.12.0
 #drogue-client = { path = "../../drogue-client" }

--- a/console-frontend/src/pages/access_tokens/create.rs
+++ b/console-frontend/src/pages/access_tokens/create.rs
@@ -4,7 +4,7 @@ use crate::{
     error::{error, ErrorNotification, ErrorNotifier},
     pages::access_tokens::success::AccessTokenCreatedSuccessModal,
 };
-use drogue_cloud_service_api::token::AccessTokenCreated;
+use drogue_cloud_service_api::token::CreatedAccessToken;
 use http::Method;
 use patternfly_yew::*;
 use yew::prelude::*;
@@ -16,7 +16,7 @@ pub struct Props {
 }
 
 pub enum Msg {
-    Success(AccessTokenCreated),
+    Success(CreatedAccessToken),
     Error(ErrorNotification),
     Create,
     Description(String),
@@ -74,7 +74,7 @@ impl Component for AccessTokenCreateModal {
                         <Button
                             variant={Variant::Primary}
                             disabled={self.fetch_task.is_some()}
-                            r#type="submit"
+                            r#type={ButtonType::Submit}
                             onclick={ctx.link().callback(|_|Msg::Create)}
                             form="create-form"
                             id="confirm-create-token"
@@ -109,7 +109,7 @@ impl AccessTokenCreateModal {
             vec![("description", description)],
             Nothing,
             vec![],
-            ctx.callback_api::<Json<AccessTokenCreated>, _>(move |response| match response {
+            ctx.callback_api::<Json<CreatedAccessToken>, _>(move |response| match response {
                 ApiResponse::Success(token, _) => Msg::Success(token),
                 ApiResponse::Failure(err) => Msg::Error(err.notify("Creation failed")),
             }),

--- a/console-frontend/src/pages/access_tokens/success.rs
+++ b/console-frontend/src/pages/access_tokens/success.rs
@@ -40,7 +40,7 @@ impl Component for AccessTokenCreatedSuccessModal {
                     footer={html!(
                         <Button
                             variant={Variant::Primary}
-                            r#type="submit"
+                            r#type={ButtonType::Submit}
                             onclick={ctx.link().callback(|_|Msg::Close)}
                         >
                             {"Close"}

--- a/console-frontend/src/pages/apps/create.rs
+++ b/console-frontend/src/pages/apps/create.rs
@@ -84,7 +84,7 @@ impl Component for CreateDialog {
                         <Button
                             variant={Variant::Primary}
                             disabled={!is_valid || self.fetch_task.is_some()}
-                            r#type="submit"
+                            r#type={ButtonType::Submit}
                             onclick={ctx.link().callback(|_|Msg::Create)}
                             form="create-form"
                         >

--- a/console-frontend/src/pages/apps/details/admin.rs
+++ b/console-frontend/src/pages/apps/details/admin.rs
@@ -233,7 +233,7 @@ impl Component for Admin {
                                                 placeholder="Select user roles"
                                                 multiple=true
                                                 variant={SelectVariant::Checkbox(ctx.link().callback(Msg::NewMemberRoles))}
-                                                badge={BadgeVariant::Values}>
+                                                chip={ChipVariant::Values}>
                                             <SelectOption<Role> value={Role::Reader} description="Read-only for app and devices details" />
                                             <SelectOption<Role> value={Role::Manager} description="Read-write for app and devices details" />
                                             <SelectOption<Role> value={Role::Subscriber} description="Consume app events" />

--- a/console-frontend/src/pages/apps/details/admin.rs
+++ b/console-frontend/src/pages/apps/details/admin.rs
@@ -7,7 +7,7 @@ use crate::{
     utils::url_encode,
 };
 use anyhow::{anyhow, Result};
-use drogue_cloud_service_api::admin::{MemberEntry, Members, Role, TransferOwnership};
+use drogue_cloud_service_api::admin::{MemberEntry, Members, Role, Roles, TransferOwnership};
 use http::{Method, StatusCode};
 use indexmap::IndexMap;
 use patternfly_yew::*;
@@ -462,7 +462,7 @@ impl Users {
         for (user, roles) in members.members {
             new_members.push(User {
                 id: user.clone(),
-                roles: roles.roles,
+                roles: roles.roles.0,
                 on_delete: link.callback(move |_| Msg::DeleteMember(user.clone())),
             });
         }
@@ -474,7 +474,6 @@ impl Users {
         }
     }
 
-    //FIXME : remove the dependency on IndexMap by using generics for the Member struct :)
     pub fn serialize(&self) -> Members {
         let mut members: IndexMap<String, MemberEntry> = IndexMap::new();
 
@@ -482,7 +481,7 @@ impl Users {
             members.insert(
                 u.id.clone(),
                 MemberEntry {
-                    roles: u.roles.clone(),
+                    roles: Roles(u.roles.clone()),
                 },
             );
         }

--- a/console-frontend/src/pages/devices/clone.rs
+++ b/console-frontend/src/pages/devices/clone.rs
@@ -86,7 +86,7 @@ impl Component for CloneDialog {
                         <Button
                             variant={Variant::Primary}
                             disabled={!is_valid || self.fetch_task.is_some()}
-                            r#type="submit"
+                            r#type={ButtonType::Submit}
                             onclick={ctx.link().callback(|_|Msg::Create)}
                             form="create-form"
                         >

--- a/console-frontend/src/pages/devices/create.rs
+++ b/console-frontend/src/pages/devices/create.rs
@@ -86,7 +86,7 @@ impl Component for CreateDialog {
                         <Button
                             variant={Variant::Primary}
                             disabled={!is_valid || self.fetch_task.is_some()}
-                            r#type="submit"
+                            r#type={ButtonType::Submit}
                             onclick={ctx.link().callback(|_|Msg::Create)}
                             form="create-form"
                         >

--- a/database-common/src/auth.rs
+++ b/database-common/src/auth.rs
@@ -1,11 +1,11 @@
 //! Common authn/authz logic
 
-use crate::{error::ServiceError, models::app::MemberEntry};
-use drogue_client::user::v1::authz::{Outcome, Permission, ResourcePermission};
-use drogue_client::admin::v1::Role;
-use drogue_cloud_service_api::{
-    auth::user::{IsAdmin, UserInformation},
+use crate::error::ServiceError;
+use drogue_client::admin::v1::{MemberEntry, Role};
+use drogue_client::user::v1::authz::{
+    ApplicationPermission, DevicePermission, Outcome, Permission,
 };
+use drogue_cloud_service_api::auth::user::{IsAdmin, UserInformation};
 use indexmap::map::IndexMap;
 use std::fmt::Debug;
 
@@ -26,7 +26,7 @@ pub fn authorize(
     identity: &UserInformation,
     permission: Permission,
 ) -> Outcome {
-    log::debug!(
+    log::warn!(
         "authorizing - resource: {:?}, identity: {:?}, permission: {:?}",
         resource,
         identity,
@@ -39,44 +39,79 @@ pub fn authorize(
         return Outcome::Allow;
     }
 
-    match permission {
-        Permission::Resource(permission) => {
+    // check the owner
+    match (resource.owner(), identity.user_id()) {
+        // If there is no owner -> allow access
+        (None, _) => return Outcome::Allow,
+        // If there is an owner and an authenticated user and both match -> allow access
+        // as the owner have all permissions on a resource
+        (Some(owner), Some(user)) if owner == user => return Outcome::Allow,
+        // The current user is not the owner, carry on..
+        _ => {}
+    }
 
-            // check the owner
-            match (resource.owner(), identity.user_id()) {
-                // If there is no owner -> allow access
-                (None, _) => Outcome::Allow,
-                // If there is an owner and an authenticated user and both match -> allow access
-                (Some(owner), Some(user)) if owner == user => Outcome::Allow,
-                // We must be owner, but are not -> deny
-                _ if permission == ResourcePermission::Own => Outcome::Deny,
-                // Check the member list
-                (Some(_), user) => {
-                    // If we don't have a user, look for the anonymous mapping
-                    let user = user.unwrap_or_default();
-                    // If there is a member in the list which matches the user ...
-                    if let Some(member) = resource.members().get(user) {
-                        match permission {
-                            // this should already be covered be the rule above
-                            ResourcePermission::Own => Outcome::Deny,
-                            ResourcePermission::Read => match member.role {
-                                Role::Reader | Role::Manager => Outcome::Allow,
-                                _ => Outcome::Deny,
-                            },
-                            ResourcePermission::Write => match member.role {
-                                Role::Manager => Outcome::Allow,
-                                _ => Outcome::Deny,
-                            },
-                            Permission::Read => Outcome::Allow,
-                        }
-                    } else {
-                        Outcome::Deny
+    // Check the member list
+    // If we don't have a user, look for the anonymous mapping
+    let user = identity.user_id().unwrap_or_default();
+    // If there is a member in the list which matches the user ...
+    if let Some(member) = resource.members().get(user) {
+        match permission {
+            Permission::App(permission) => {
+                match permission {
+                    // this should already be covered be the rule above
+                    ApplicationPermission::Transfer => Outcome::Deny,
+                    // short of transferring the app, the admin can do anything
+                    _ if member.roles.contains(&Role::Admin) => Outcome::Allow,
+                    // Read is allowed for Reader, Writer and Manager
+                    ApplicationPermission::Read
+                        if member.roles.contains(&Role::Reader)
+                            || member.roles.contains(&Role::Manager) =>
+                    {
+                        Outcome::Allow
                     }
+                    // Write is allowed for Admin and Manager
+                    ApplicationPermission::Write if member.roles.contains(&Role::Manager) => {
+                        Outcome::Allow
+                    }
+
+                    ApplicationPermission::Command if member.roles.contains(&Role::Publisher) => {
+                        Outcome::Allow
+                    }
+                    ApplicationPermission::Subscribe
+                        if member.roles.contains(&Role::Subscriber) =>
+                    {
+                        Outcome::Allow
+                    }
+                    _ => Outcome::Deny,
                 }
             }
-        },
-        // TODO: implement permission check for access tokens operations
-        Permission::Token(t) => todo!()
+            Permission::Device(permission) => {
+                // When it comes to devices the admin can do anything
+                if member.roles.contains(&Role::Admin) {
+                    return Outcome::Allow;
+                }
+                match permission {
+                    DevicePermission::Read
+                        if member.roles.contains(&Role::Reader)
+                            || member.roles.contains(&Role::Manager) =>
+                    {
+                        Outcome::Allow
+                    }
+                    DevicePermission::Write
+                    | DevicePermission::Create
+                    | DevicePermission::Delete
+                        if member.roles.contains(&Role::Manager) =>
+                    {
+                        Outcome::Allow
+                    }
+                    _ => Outcome::Deny,
+                }
+            }
+            // TODO: implement permission check for access tokens operations
+            Permission::Token(permission) => todo!(),
+        }
+    } else {
+        Outcome::Deny
     }
 }
 
@@ -110,159 +145,5 @@ where
     match authorize(resource, identity, permission) {
         Outcome::Allow => Ok(()),
         Outcome::Deny => Err(f()),
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use drogue_cloud_service_api::auth::user::UserDetails;
-
-    #[derive(Debug)]
-    struct MockResource {
-        owner: String,
-        members: IndexMap<String, MemberEntry>,
-    }
-
-    impl Resource for MockResource {
-        fn owner(&self) -> Option<&str> {
-            Some(&self.owner)
-        }
-
-        fn members(&self) -> &IndexMap<String, MemberEntry> {
-            &self.members
-        }
-    }
-
-    macro_rules! resource {
-        ($owner:literal, [$( $id:literal => $role:expr),*]) => {
-            {
-                #[allow(unused_mut)]
-                let mut members = IndexMap::new();
-                $(
-                    members.insert($id.into(), MemberEntry { role: $role });
-                )*
-                MockResource {
-                    owner: $owner.into(),
-                    members,
-                }
-            }
-
-        };
-    }
-
-    macro_rules! test_auth {
-        ($user:expr, $resource:expr, [$( $perm:expr => $outcome:expr ),*]) => {
-            {
-                let user = $user;
-                let resource = $resource;
-                $(assert_eq!(authorize(&user, &resource, $perm), $outcome, "Expected outcome '{:?}' for permission '{:?}'", $outcome, $perm);)*
-            }
-        };
-    }
-
-    fn user(id: &str, roles: &[&str]) -> UserInformation {
-        UserInformation::Authenticated(UserDetails {
-            user_id: id.into(),
-            roles: roles.iter().map(ToString::to_string).collect(),
-        })
-    }
-
-    #[test]
-    fn test_auth_owner() {
-        test_auth!(
-            resource!("foo", []),
-            user("foo", &[]),
-            [
-                Permission::Owner => Outcome::Allow,
-                Permission::Admin => Outcome::Allow,
-                Permission::Write => Outcome::Allow,
-                Permission::Read => Outcome::Allow
-            ]
-        )
-    }
-
-    #[test]
-    fn test_auth_sys_admin() {
-        test_auth!(
-            resource!("foo", []),
-            user("bar", &["drogue-admin"]),
-            [
-                Permission::Owner => Outcome::Allow,
-                Permission::Admin => Outcome::Allow,
-                Permission::Write => Outcome::Allow,
-                Permission::Read => Outcome::Allow
-            ]
-        )
-    }
-
-    #[test]
-    fn test_auth_resource_admin() {
-        test_auth!(
-            resource!("foo", ["bar" => Role::Admin]),
-            user("bar", &[]),
-            [
-                Permission::Owner => Outcome::Deny,
-                Permission::Admin => Outcome::Allow,
-                Permission::Write => Outcome::Allow,
-                Permission::Read => Outcome::Allow
-            ]
-        )
-    }
-
-    #[test]
-    fn test_auth_resource_manager() {
-        test_auth!(
-            resource!("foo", ["bar" => Role::Manager]),
-            user("bar", &[]),
-            [
-                Permission::Owner => Outcome::Deny,
-                Permission::Admin => Outcome::Deny,
-                Permission::Write => Outcome::Allow,
-                Permission::Read => Outcome::Allow
-            ]
-        )
-    }
-
-    #[test]
-    fn test_auth_resource_reader() {
-        test_auth!(
-            resource!("foo", ["bar" => Role::Reader]),
-            user("bar", &[]),
-            [
-                Permission::Owner => Outcome::Deny,
-                Permission::Admin => Outcome::Deny,
-                Permission::Write => Outcome::Deny,
-                Permission::Read => Outcome::Allow
-            ]
-        )
-    }
-
-    #[test]
-    fn test_auth_anon() {
-        test_auth!(
-            resource!("foo", ["" => Role::Reader]),
-            UserInformation::Anonymous,
-            [
-                Permission::Owner => Outcome::Deny,
-                Permission::Admin => Outcome::Deny,
-                Permission::Write => Outcome::Deny,
-                Permission::Read => Outcome::Allow
-            ]
-        )
-    }
-
-    #[test]
-    fn test_reject_anon() {
-        test_auth!(
-            resource!("foo", ["bar" => Role::Reader]),
-            UserInformation::Anonymous,
-            [
-                Permission::Owner => Outcome::Deny,
-                Permission::Admin => Outcome::Deny,
-                Permission::Write => Outcome::Deny,
-                Permission::Read => Outcome::Deny
-            ]
-        )
     }
 }

--- a/database-common/src/models/app.rs
+++ b/database-common/src/models/app.rs
@@ -69,6 +69,10 @@ impl Resource for Application {
     fn members(&self) -> &IndexMap<String, MemberEntry> {
         &self.members
     }
+
+    fn name(&self) -> &String {
+        &self.name
+    }
 }
 
 /// Extract a section from the application data. Prevents cloning the whole struct.

--- a/database-common/src/models/app.rs
+++ b/database-common/src/models/app.rs
@@ -14,10 +14,11 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use core::pin::Pin;
 use drogue_client::{meta, registry};
-use drogue_cloud_service_api::{admin::Role, auth::user::UserInformation, labels::LabelSelector};
+use drogue_cloud_service_api::{
+    admin::MemberEntry, auth::user::UserInformation, labels::LabelSelector,
+};
 use futures::{future, Stream, TryStreamExt};
 use indexmap::map::IndexMap;
-use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::collections::{hash_map::RandomState, HashMap, HashSet};
 use tokio_postgres::{
@@ -68,11 +69,6 @@ impl Resource for Application {
     fn members(&self) -> &IndexMap<String, MemberEntry> {
         &self.members
     }
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct MemberEntry {
-    pub role: Role,
 }
 
 /// Extract a section from the application data. Prevents cloning the whole struct.

--- a/database-common/tests/auth.rs
+++ b/database-common/tests/auth.rs
@@ -13,6 +13,7 @@ use indexmap::IndexMap;
 struct MockResource {
     owner: String,
     members: IndexMap<String, MemberEntry>,
+    name: String,
 }
 
 impl Resource for MockResource {
@@ -22,6 +23,9 @@ impl Resource for MockResource {
 
     fn members(&self) -> &IndexMap<String, MemberEntry> {
         &self.members
+    }
+    fn name(&self) -> &String {
+        &self.name
     }
 }
 

--- a/database-common/tests/auth.rs
+++ b/database-common/tests/auth.rs
@@ -1,0 +1,296 @@
+use drogue_cloud_database_common::auth::{authorize, Resource};
+use drogue_cloud_service_api::auth::user::UserDetails;
+use drogue_cloud_service_common::auth::UserInformation;
+
+use drogue_client::admin::v1::{MemberEntry, Role};
+use drogue_client::user::v1::authz::{
+    ApplicationPermission, DevicePermission, Outcome, Permission,
+};
+
+use indexmap::IndexMap;
+
+#[derive(Debug)]
+struct MockResource {
+    owner: String,
+    members: IndexMap<String, MemberEntry>,
+}
+
+impl Resource for MockResource {
+    fn owner(&self) -> Option<&str> {
+        Some(&self.owner)
+    }
+
+    fn members(&self) -> &IndexMap<String, MemberEntry> {
+        &self.members
+    }
+}
+
+macro_rules! resource {
+        ($owner:literal, [$( $id:literal => $role:expr),*]) => {
+            {
+                #[allow(unused_mut)]
+                let mut members = IndexMap::new();
+                $(
+                    members.insert($id.into(), MemberEntry { roles: $role });
+                )*
+                MockResource {
+                    owner: $owner.into(),
+                    members,
+                }
+            }
+
+        };
+    }
+
+macro_rules! test_auth {
+        ($user:expr, $resource:expr, [$( $perm:expr => $outcome:expr ),*]) => {
+            {
+                let user = $user;
+                let resource = $resource;
+                $(assert_eq!(authorize(&user, &resource, $perm), $outcome, "Expected outcome '{:?}' for permission '{:?}'", $outcome, $perm);)*
+            }
+        };
+    }
+
+fn user(id: &str, roles: &[&str]) -> UserInformation {
+    UserInformation::Authenticated(UserDetails {
+        user_id: id.into(),
+        roles: roles.iter().map(ToString::to_string).collect(),
+    })
+}
+
+#[test]
+fn test_auth_owner() {
+    test_auth!(
+        resource!("foo", []),
+        user("foo", &[]),
+        [
+            Permission::App(ApplicationPermission::Create) => Outcome::Allow,
+            Permission::App(ApplicationPermission::Delete) => Outcome::Allow,
+            Permission::App(ApplicationPermission::Write) => Outcome::Allow,
+            Permission::App(ApplicationPermission::Read) => Outcome::Allow,
+            Permission::App(ApplicationPermission::Transfer) => Outcome::Allow,
+            Permission::App(ApplicationPermission::Subscribe) => Outcome::Allow,
+            Permission::App(ApplicationPermission::Command) => Outcome::Allow,
+            Permission::App(ApplicationPermission::Members) => Outcome::Allow,
+            Permission::Device(DevicePermission::Create) => Outcome::Allow,
+            Permission::Device(DevicePermission::Delete) => Outcome::Allow,
+            Permission::Device(DevicePermission::Write) => Outcome::Allow,
+            Permission::Device(DevicePermission::Read) => Outcome::Allow
+        ]
+    )
+}
+
+#[test]
+fn test_auth_sys_admin() {
+    test_auth!(
+        resource!("foo", []),
+        user("bar", &["drogue-admin"]),
+        [
+            Permission::App(ApplicationPermission::Create) => Outcome::Allow,
+            Permission::App(ApplicationPermission::Delete) => Outcome::Allow,
+            Permission::App(ApplicationPermission::Write) => Outcome::Allow,
+            Permission::App(ApplicationPermission::Read) => Outcome::Allow,
+            Permission::App(ApplicationPermission::Transfer) => Outcome::Allow,
+            Permission::App(ApplicationPermission::Subscribe) => Outcome::Allow,
+            Permission::App(ApplicationPermission::Command) => Outcome::Allow,
+            Permission::App(ApplicationPermission::Members) => Outcome::Allow,
+            Permission::Device(DevicePermission::Create) => Outcome::Allow,
+            Permission::Device(DevicePermission::Delete) => Outcome::Allow,
+            Permission::Device(DevicePermission::Write) => Outcome::Allow,
+            Permission::Device(DevicePermission::Read) => Outcome::Allow
+        ]
+    )
+}
+
+#[test]
+fn test_auth_resource_admin() {
+    test_auth!(
+        resource!("foo", ["bar" => vec![Role::Admin]]),
+        user("bar", &[]),
+        [
+            Permission::App(ApplicationPermission::Transfer) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Create) => Outcome::Allow,
+            Permission::App(ApplicationPermission::Delete) => Outcome::Allow,
+            Permission::App(ApplicationPermission::Write) => Outcome::Allow,
+            Permission::App(ApplicationPermission::Read) => Outcome::Allow,
+            Permission::App(ApplicationPermission::Subscribe) => Outcome::Allow,
+            Permission::App(ApplicationPermission::Command) => Outcome::Allow,
+            Permission::App(ApplicationPermission::Members) => Outcome::Allow,
+            Permission::Device(DevicePermission::Create) => Outcome::Allow,
+            Permission::Device(DevicePermission::Delete) => Outcome::Allow,
+            Permission::Device(DevicePermission::Write) => Outcome::Allow,
+            Permission::Device(DevicePermission::Read) => Outcome::Allow
+        ]
+    )
+}
+
+#[test]
+fn test_auth_resource_manager() {
+    test_auth!(
+        resource!("foo", ["bar" =>  vec![Role::Manager]]),
+        user("bar", &[]),
+        [
+            Permission::App(ApplicationPermission::Transfer) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Delete) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Write) => Outcome::Allow,
+            Permission::App(ApplicationPermission::Read) => Outcome::Allow,
+            Permission::App(ApplicationPermission::Subscribe) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Command) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Members) => Outcome::Deny,
+            Permission::Device(DevicePermission::Create) => Outcome::Allow,
+            Permission::Device(DevicePermission::Delete) => Outcome::Allow,
+            Permission::Device(DevicePermission::Write) => Outcome::Allow,
+            Permission::Device(DevicePermission::Read) => Outcome::Allow
+        ]
+    )
+}
+
+#[test]
+fn test_auth_resource_reader_subscriber() {
+    test_auth!(
+        resource!("foo", ["bar" =>  vec![Role::Reader, Role::Subscriber]]),
+        user("bar", &[]),
+        [
+            Permission::App(ApplicationPermission::Transfer) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Delete) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Write) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Read) => Outcome::Allow,
+            Permission::App(ApplicationPermission::Subscribe) => Outcome::Allow,
+            Permission::App(ApplicationPermission::Command) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Members) => Outcome::Deny,
+            Permission::Device(DevicePermission::Create) => Outcome::Deny,
+            Permission::Device(DevicePermission::Delete) => Outcome::Deny,
+            Permission::Device(DevicePermission::Write) => Outcome::Deny,
+            Permission::Device(DevicePermission::Read) => Outcome::Allow
+        ]
+    )
+}
+
+#[test]
+fn test_auth_resource_reader() {
+    test_auth!(
+        resource!("foo", ["bar" => vec![Role::Reader]]),
+        user("bar", &[]),
+        [
+            Permission::App(ApplicationPermission::Transfer) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Delete) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Write) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Read) => Outcome::Allow,
+            Permission::App(ApplicationPermission::Subscribe) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Command) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Members) => Outcome::Deny,
+            Permission::Device(DevicePermission::Create) => Outcome::Deny,
+            Permission::Device(DevicePermission::Delete) => Outcome::Deny,
+            Permission::Device(DevicePermission::Write) => Outcome::Deny,
+            Permission::Device(DevicePermission::Read) => Outcome::Allow
+        ]
+    )
+}
+
+#[test]
+fn test_auth_resource_subscriber() {
+    test_auth!(
+        resource!("foo", ["bar" => vec![Role::Subscriber]]),
+        user("bar", &[]),
+        [
+            Permission::App(ApplicationPermission::Transfer) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Delete) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Write) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Read) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Subscribe) => Outcome::Allow,
+            Permission::App(ApplicationPermission::Command) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Members) => Outcome::Deny,
+            Permission::Device(DevicePermission::Create) => Outcome::Deny,
+            Permission::Device(DevicePermission::Delete) => Outcome::Deny,
+            Permission::Device(DevicePermission::Write) => Outcome::Deny,
+            Permission::Device(DevicePermission::Read) => Outcome::Deny
+        ]
+    )
+}
+
+#[test]
+fn test_auth_resource_publisher() {
+    test_auth!(
+        resource!("foo", ["bar" => vec![Role::Publisher]]),
+        user("bar", &[]),
+        [
+            Permission::App(ApplicationPermission::Transfer) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Delete) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Write) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Read) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Subscribe) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Command) => Outcome::Allow,
+            Permission::App(ApplicationPermission::Members) => Outcome::Deny,
+            Permission::Device(DevicePermission::Create) => Outcome::Deny,
+            Permission::Device(DevicePermission::Delete) => Outcome::Deny,
+            Permission::Device(DevicePermission::Write) => Outcome::Deny,
+            Permission::Device(DevicePermission::Read) => Outcome::Deny
+        ]
+    )
+}
+
+#[test]
+fn test_auth_resource_publisher_subscriber() {
+    test_auth!(
+        resource!("foo", ["bar" => vec![Role::Publisher, Role::Subscriber]]),
+        user("bar", &[]),
+        [
+            Permission::App(ApplicationPermission::Transfer) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Delete) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Write) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Read) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Subscribe) => Outcome::Allow,
+            Permission::App(ApplicationPermission::Command) => Outcome::Allow,
+            Permission::App(ApplicationPermission::Members) => Outcome::Deny,
+            Permission::Device(DevicePermission::Create) => Outcome::Deny,
+            Permission::Device(DevicePermission::Delete) => Outcome::Deny,
+            Permission::Device(DevicePermission::Write) => Outcome::Deny,
+            Permission::Device(DevicePermission::Read) => Outcome::Deny
+        ]
+    )
+}
+
+#[test]
+fn test_auth_anon() {
+    test_auth!(
+        resource!("foo", ["" => vec![Role::Subscriber, Role::Reader]]),
+        UserInformation::Anonymous,
+        [
+            Permission::App(ApplicationPermission::Transfer) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Create) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Delete) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Write) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Read) => Outcome::Allow,
+            Permission::App(ApplicationPermission::Subscribe) => Outcome::Allow,
+            Permission::App(ApplicationPermission::Command) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Members) => Outcome::Deny,
+            Permission::Device(DevicePermission::Create) => Outcome::Deny,
+            Permission::Device(DevicePermission::Delete) => Outcome::Deny,
+            Permission::Device(DevicePermission::Write) => Outcome::Deny,
+            Permission::Device(DevicePermission::Read) => Outcome::Allow
+        ]
+    )
+}
+
+#[test]
+fn test_reject_anon() {
+    test_auth!(
+        resource!("foo", ["bar" => vec![Role::Reader]]),
+        UserInformation::Anonymous,
+        [
+            Permission::App(ApplicationPermission::Transfer) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Create) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Delete) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Write) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Read) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Subscribe) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Command) => Outcome::Deny,
+            Permission::App(ApplicationPermission::Members) => Outcome::Deny,
+            Permission::Device(DevicePermission::Create) => Outcome::Deny,
+            Permission::Device(DevicePermission::Delete) => Outcome::Deny,
+            Permission::Device(DevicePermission::Write) => Outcome::Deny,
+            Permission::Device(DevicePermission::Read) => Outcome::Deny
+        ]
+    )
+}

--- a/device-management-service/src/service/admin/mod.rs
+++ b/device-management-service/src/service/admin/mod.rs
@@ -6,7 +6,7 @@ use drogue_cloud_database_common::{
     auth::ensure_with,
     error::ServiceError,
     models::{
-        app::{self, ApplicationAccessor, PostgresApplicationAccessor},
+        app::{ApplicationAccessor, PostgresApplicationAccessor},
         Lock,
     },
 };
@@ -52,7 +52,7 @@ where
         ensure_with(
             &app,
             identity,
-            Permission::App(ApplicationPermission::Own),
+            Permission::App(ApplicationPermission::Transfer),
             || ServiceError::NotFound,
         )?;
 

--- a/device-management-service/src/service/admin/mod.rs
+++ b/device-management-service/src/service/admin/mod.rs
@@ -224,20 +224,12 @@ where
 
         // ensure we are permitted to perform the operation
 
-        log::warn!(
-            "get members - identity: {:?} - app_owner: {:?}",
-            &identity,
-            &app.owner
-        );
-        println!("i try to get members and I should not get 404 because i am the app owner.");
-
-        // FIXME : this is just to have always allow ?
-        let _ = ensure_with(
+        ensure_with(
             &app,
             identity,
             Permission::App(ApplicationPermission::Members),
             || ServiceError::NotFound,
-        );
+        )?;
 
         // get operation
         let mut members: IndexMap<String, MemberEntry> = IndexMap::new();

--- a/device-management-service/src/service/mod.rs
+++ b/device-management-service/src/service/mod.rs
@@ -6,6 +6,7 @@ mod x509;
 
 use crate::{service::error::PostgresManagementServiceError, utils::epoch};
 use deadpool_postgres::{Pool, Transaction};
+use drogue_client::user::v1::authz::ApplicationPermission;
 use drogue_client::{registry, user::v1::authz::Permission, Translator};
 use drogue_cloud_database_common::{
     auth::ensure,
@@ -232,7 +233,11 @@ where
         }?;
 
         if let Some(identity) = identity {
-            ensure(&current, identity, Permission::Write)?;
+            ensure(
+                &current,
+                identity,
+                Permission::App(ApplicationPermission::Write),
+            )?;
         }
 
         utils::check_versions(expected_uid, expected_resource_version, &current)?;

--- a/mqtt-integration/src/service/session.rs
+++ b/mqtt-integration/src/service/session.rs
@@ -8,6 +8,7 @@ use crate::{
 use async_trait::async_trait;
 use drogue_client::registry;
 use drogue_client::user;
+use drogue_client::user::v1::authz::ApplicationPermission;
 use drogue_cloud_endpoint_common::sender::UpstreamSender;
 use drogue_cloud_event_common::stream::CustomAck;
 use drogue_cloud_integration_common::{
@@ -164,7 +165,7 @@ impl Session {
                 self.authorize(
                     app.to_string(),
                     user_auth,
-                    user::v1::authz::Permission::Read,
+                    user::v1::authz::Permission::App(ApplicationPermission::Subscribe),
                 )
                 .await
                 .map_err(|_| v5::codec::SubscribeAckReason::NotAuthorized)?;
@@ -273,7 +274,7 @@ impl mqtt::Session for Session {
                 self.authorize(
                     app.to_string(),
                     user_auth,
-                    user::v1::authz::Permission::Write,
+                    user::v1::authz::Permission::App(ApplicationPermission::Command),
                 )
                 .await
                 .map_err(|_| PublishError::NotAuthorized)?;

--- a/service-api/src/admin/mod.rs
+++ b/service-api/src/admin/mod.rs
@@ -1,45 +1,4 @@
-use core::fmt::{Display, Formatter};
-use indexmap::IndexMap;
-use serde::{Deserialize, Serialize};
-
-#[derive(Serialize, Deserialize, Clone, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct TransferOwnership {
-    pub new_user: String,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct Members {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub resource_version: Option<String>,
-    #[serde(default)]
-    pub members: IndexMap<String, MemberEntry>,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct MemberEntry {
-    pub role: Role,
-}
-
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub enum Role {
-    /// Allow everything, including changing members
-    Admin,
-    /// Allow reading and writing, but not changing members.
-    Manager,
-    /// Allow reading only.
-    Reader,
-}
-
-impl Display for Role {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Admin => write!(f, "Administrator"),
-            Self::Manager => write!(f, "Manager"),
-            Self::Reader => write!(f, "Reader"),
-        }
-    }
-}
+pub use drogue_client::admin::v1::MemberEntry;
+pub use drogue_client::admin::v1::Members;
+pub use drogue_client::admin::v1::Role;
+pub use drogue_client::admin::v1::TransferOwnership;

--- a/service-api/src/admin/mod.rs
+++ b/service-api/src/admin/mod.rs
@@ -1,4 +1,5 @@
 pub use drogue_client::admin::v1::MemberEntry;
 pub use drogue_client::admin::v1::Members;
 pub use drogue_client::admin::v1::Role;
+pub use drogue_client::admin::v1::Roles;
 pub use drogue_client::admin::v1::TransferOwnership;

--- a/service-api/src/token.rs
+++ b/service-api/src/token.rs
@@ -1,13 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct AccessToken {
-    pub prefix: String,
-    pub created: DateTime<Utc>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-}
+pub use drogue_client::tokens::v1::*;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AccessTokenData {
@@ -15,15 +9,5 @@ pub struct AccessTokenData {
     pub created: DateTime<Utc>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct AccessTokenCreationOptions {
-    pub description: Option<String>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct AccessTokenCreated {
-    pub prefix: String,
-    pub token: String,
+    pub scopes: Option<AccessTokenScopes>,
 }

--- a/service-api/src/token.rs
+++ b/service-api/src/token.rs
@@ -9,5 +9,5 @@ pub struct AccessTokenData {
     pub created: DateTime<Utc>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    pub scopes: Option<AccessTokenScopes>,
+    pub claims: Option<AccessTokenClaims>,
 }

--- a/user-auth-service/src/service.rs
+++ b/user-auth-service/src/service.rs
@@ -64,7 +64,7 @@ impl From<Context> for UserInformation {
                 user_id,
                 roles: ctx.0.roles,
                 // fixme
-                scopes: None,
+                claims: None,
             }),
             _ => Self::Anonymous,
         }

--- a/user-auth-service/src/service.rs
+++ b/user-auth-service/src/service.rs
@@ -63,6 +63,8 @@ impl From<Context> for UserInformation {
             Some(user_id) if !user_id.is_empty() => Self::Authenticated(UserDetails {
                 user_id,
                 roles: ctx.0.roles,
+                // fixme
+                scopes: None,
             }),
             _ => Self::Anonymous,
         }

--- a/websocket-integration/src/lib.rs
+++ b/websocket-integration/src/lib.rs
@@ -6,7 +6,7 @@ mod wshandler;
 use crate::service::Service;
 use actix::Actor;
 use actix_web::web;
-use drogue_client::user::v1::authz::{Permission, ResourcePermission};
+use drogue_client::user::v1::authz::{ApplicationPermission, Permission};
 use drogue_cloud_service_api::{
     kafka::KafkaClientConfig,
     webapp::{self as actix_web},
@@ -91,7 +91,7 @@ pub async fn run(config: Config, startup: &mut dyn Startup) -> anyhow::Result<()
             web::scope("/{application}")
                 .wrap(ApplicationAuthorizer::wrapping(
                     user_auth.clone(),
-                    Permission::Resource(ResourcePermission::Subscribe),
+                    Permission::App(ApplicationPermission::Subscribe),
                 ))
                 .wrap(AuthN::from((
                     authenticator.clone(),

--- a/websocket-integration/src/lib.rs
+++ b/websocket-integration/src/lib.rs
@@ -6,7 +6,7 @@ mod wshandler;
 use crate::service::Service;
 use actix::Actor;
 use actix_web::web;
-use drogue_client::user::v1::authz::Permission;
+use drogue_client::user::v1::authz::{Permission, ResourcePermission};
 use drogue_cloud_service_api::{
     kafka::KafkaClientConfig,
     webapp::{self as actix_web},
@@ -91,7 +91,7 @@ pub async fn run(config: Config, startup: &mut dyn Startup) -> anyhow::Result<()
             web::scope("/{application}")
                 .wrap(ApplicationAuthorizer::wrapping(
                     user_auth.clone(),
-                    Permission::Read,
+                    Permission::Resource(ResourcePermission::Subscribe),
                 ))
                 .wrap(AuthN::from((
                     authenticator.clone(),

--- a/websocket-integration/src/wshandler/mod.rs
+++ b/websocket-integration/src/wshandler/mod.rs
@@ -12,7 +12,7 @@ use chrono::{DateTime, TimeZone, Utc};
 use cloudevents::AttributesReader;
 use drogue_client::{
     integration::ws::v1::client,
-    user::{self, v1::authz},
+    user::{self, v1::authz, v1::authz::ResourcePermission},
 };
 use drogue_cloud_service_api::{auth::user::UserInformation, webapp::http::ws::CloseCode};
 use drogue_cloud_service_common::auth::openid::{self, CustomClaims};
@@ -60,7 +60,7 @@ impl AuthContext {
             .user_auth
             .authorize(authz::AuthorizationRequest {
                 application: self.application.clone(),
-                permission: authz::Permission::Read,
+                permission: authz::Permission::Resource(ResourcePermission::Subscribe),
                 user_id: user.user_id().map(ToString::to_string),
                 roles: user.roles().clone(),
             })

--- a/websocket-integration/src/wshandler/mod.rs
+++ b/websocket-integration/src/wshandler/mod.rs
@@ -12,7 +12,7 @@ use chrono::{DateTime, TimeZone, Utc};
 use cloudevents::AttributesReader;
 use drogue_client::{
     integration::ws::v1::client,
-    user::{self, v1::authz, v1::authz::ResourcePermission},
+    user::{self, v1::authz, v1::authz::ApplicationPermission},
 };
 use drogue_cloud_service_api::{auth::user::UserInformation, webapp::http::ws::CloseCode};
 use drogue_cloud_service_common::auth::openid::{self, CustomClaims};
@@ -60,7 +60,7 @@ impl AuthContext {
             .user_auth
             .authorize(authz::AuthorizationRequest {
                 application: self.application.clone(),
-                permission: authz::Permission::Resource(ResourcePermission::Subscribe),
+                permission: authz::Permission::App(ApplicationPermission::Subscribe),
                 user_id: user.user_id().map(ToString::to_string),
                 roles: user.roles().clone(),
             })


### PR DESCRIPTION
This is the initial implementation for https://github.com/drogue-iot/rfcs/pull/19

This add a few new permissions and associated roles.  It also add scopes to personal access tokens. 

What is still TODO  : 
- [x] Verify the tokens scopes on the tokens operation (allowing or not a token to create other tokens). Currently there is no AuthZ on this endpoint.
- [x] Console frontend form to create tokens with scopes
- [ ] More manual testing
- [ ] System tests
- [ ] Some others things I probably forgot

It relies on a few other PRs : 
 https://github.com/drogue-iot/drogue-bazaar/pull/5
https://github.com/drogue-iot/drogue-client/pull/20
https://github.com/ctron/patternfly-yew/pull/23